### PR TITLE
Migrate "add_initial_metadata" to "bootstrap"

### DIFF
--- a/repository_service_tuf_api/bootstrap.py
+++ b/repository_service_tuf_api/bootstrap.py
@@ -259,7 +259,7 @@ def post_bootstrap(payload):
     logging.debug(f"Bootstrap task {task_id} sent")
     repository_metadata.apply_async(
         kwargs={
-            "action": "add_initial_metadata",
+            "action": "bootstrap",
             "payload": payload.dict(by_alias=True, exclude_none=True),
         },
         task_id=task_id,


### PR DESCRIPTION
The RSTUF worker is deprecating add_initial_metadata and replacing by bootstrap

This patch removes the old function and add the replaced one.

Closes #108

Signed-off-by: juniorlpa <luiz.pandradejr@gmail.com>