### PR TITLE
Fix coverage stats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: Tests and Lint
 on:
   workflow_dispatch:
   pull_request:
+  push:
+    branches:
+      - "main"
 
 jobs:
   build:


### PR DESCRIPTION
The coverage must run in the push to main branch.
It will give the accurated stats in the Codecov

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>