### PR TITLE
feat: add dependabot to monitor dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  # Monitor Github Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "10:00"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 10
+  # Monitor Python test dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "10:00"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,16 +7,17 @@ updates:
       interval: "daily"
       time: "10:00"
     commit-message:
-      prefix: "chore"
+      prefix: "build"
       include: "scope"
     open-pull-requests-limit: 10
-  # Monitor Python test dependencies
+  # Monitor Python dependencies
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
       time: "10:00"
     commit-message:
-      prefix: "chore"
+      prefix: "build"
+      prefix-development: "build-dev"
       include: "scope"
     open-pull-requests-limit: 10


### PR DESCRIPTION
The following PR adds Dependabot to monitor for dependency updates

Fixes: https://github.com/vmware/repository-service-tuf/issues/56 and https://github.com/vmware/repository-service-tuf/issues/57

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>