### PR TITLE
Add pre-commit tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.3.0
+  hooks:
+  - id: check-added-large-files
+  - id: end-of-file-fixer
+    files: 'repository_service_tuf_api/'
+  - id: trailing-whitespace
+    files: 'repository_service_tuf_api/'
+  - id: check-yaml
+    files: '.github/'
+- repo: https://github.com/pycqa/flake8
+  rev: '5.0.4'
+  hooks:
+  - id: flake8
+    exclude: repository_service_tuf_api/__init__.py|venv|.venv|setting.py|.git|.tox|dist|docs|/*lib/python*|/*egg|build|tools
+- repo: https://github.com/PyCQA/isort
+  rev: '5.10.1'
+  hooks:
+  - id: isort
+    args: [-l79, --profile, black, --check, --diff, .]
+- repo: https://github.com/psf/black
+  rev: '22.10.0'
+  hooks:
+  - id: black
+    args: [-l79, --check, --diff, .]
+- repo: local
+  hooks:
+    - id: tox-requirements
+      name: run requirements check from tox
+      description: Checks if `make requirements` is up-to-date
+      entry: tox -e requirements
+      language: system
+      files: ''
+      verbose: true

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ requirements:
 	pipenv requirements > requirements.txt
 	pipenv requirements --dev > requirements-dev.txt
 
+precommit:
+	pre-commit install
+	pre-commit autoupdate
+	pre-commit run --all-files --show-diff-on-failure
+
 coverage:
 	coverage report
 	coverage html -i

--- a/Pipfile
+++ b/Pipfile
@@ -39,6 +39,7 @@ sphinxcontrib-plantuml = "*"
 sphinxcontrib-openapi = "*"
 mistune = "==0.8.4"
 myst-parser = "*"
+pre-commit = "*"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b0cc5fb9bf134b06397185496cfdb6a9806da373acacc108bbd25384b49d5bdc"
+            "sha256": "e76f55495533f0a49723757b4e4c4405089fd708d854f569fc89e408e1b158e6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -164,7 +164,7 @@
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
                 "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2.1.1"
         },
         "click": {
@@ -248,7 +248,7 @@
                 "sha256:0f7569a4a6ff151958b64304071d370daa3243d15941a7beedf0c9fe5105603e",
                 "sha256:a851e51367fb93e9e1361732c1d60dab63eff98712e503ea7d92e6eccb109b4f"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "markers": "python_version >= '3.6' and python_full_version < '4.0.0'",
             "version": "==2.2.1"
         },
         "dynaconf": {
@@ -565,7 +565,7 @@
                 "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
                 "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4'",
+            "markers": "python_version >= '3.7' and python_full_version < '4.0.0'",
             "version": "==2.28.1"
         },
         "rsa": {
@@ -573,7 +573,7 @@
                 "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7",
                 "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version >= '3.6' and python_full_version < '4.0.0'",
             "version": "==4.9"
         },
         "six": {
@@ -667,7 +667,7 @@
                 "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
                 "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_full_version < '4.0.0'",
             "version": "==1.26.12"
         },
         "uvicorn": {
@@ -892,12 +892,20 @@
             ],
             "version": "==1.15.1"
         },
+        "cfgv": {
+            "hashes": [
+                "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426",
+                "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"
+            ],
+            "markers": "python_full_version >= '3.6.1'",
+            "version": "==3.3.1"
+        },
         "charset-normalizer": {
             "hashes": [
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
                 "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2.1.1"
         },
         "click": {
@@ -1025,6 +1033,14 @@
             ],
             "index": "pypi",
             "version": "==5.0.4"
+        },
+        "identify": {
+            "hashes": [
+                "sha256:6c32dbd747aa4ceee1df33f25fed0b0f6e0d65721b15bd151307ff7056d50245",
+                "sha256:b276db7ec52d7e89f5bc4653380e33054ddc803d25875952ad90b0f012cbcdaa"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.5.6"
         },
         "idna": {
             "hashes": [
@@ -1188,6 +1204,14 @@
             "index": "pypi",
             "version": "==0.18.1"
         },
+        "nodeenv": {
+            "hashes": [
+                "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e",
+                "sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==1.7.0"
+        },
         "packaging": {
             "hashes": [
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
@@ -1219,6 +1243,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==1.0.0"
+        },
+        "pre-commit": {
+            "hashes": [
+                "sha256:51a5ba7c480ae8072ecdb6933df22d2f812dc897d5fe848778116129a681aac7",
+                "sha256:a978dac7bc9ec0bcee55c18a277d553b0f419d259dadb4b9418ff2d00eb43959"
+            ],
+            "index": "pypi",
+            "version": "==2.20.0"
         },
         "pretend": {
             "hashes": [
@@ -1368,8 +1400,16 @@
                 "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
                 "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4'",
+            "markers": "python_version >= '3.7' and python_full_version < '4.0.0'",
             "version": "==2.28.1"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:512e5536220e38146176efb833d4a62aa726b7bbff82cfbc8ba9eaa3996e0b17",
+                "sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==65.5.0"
         },
         "six": {
             "hashes": [
@@ -1472,6 +1512,14 @@
             "index": "pypi",
             "version": "==1.1.5"
         },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
+        },
         "tomli": {
             "hashes": [
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
@@ -1501,7 +1549,7 @@
                 "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
                 "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_full_version < '4.0.0'",
             "version": "==1.26.12"
         },
         "virtualenv": {
@@ -1522,11 +1570,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:3a7af91c3db40ec72dd9d154ae18e008c69efe8ca88dde4f9a731bb82fe2f9eb",
-                "sha256:972cfa31bc2fedd3fa838a51e9bc7e64b7fb725a8c00e7431554311f180e9980"
+                "sha256:4fcb6f278987a6605757302a6e40e896257570d11c51628968ccb2a47e80c6c1",
+                "sha256:7a7262fd930bd3e36c50b9a64897aec3fafff3dfdeec9623ae22b40e93f99bb8"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.9.0"
+            "version": "==3.10.0"
         }
     }
 }

--- a/README.rst
+++ b/README.rst
@@ -137,3 +137,16 @@ Updating requirements files from Pipenv
 .. code:: shell
 
   $ make requirements
+
+
+Installing & enabling pre-commit
+================================
+
+The pre-commit tool is installed as part of the development requirements.
+
+To automatically run checks before you commit your changes you should install
+the git hook scripts with **pre-commit**:
+
+.. code:: shell
+
+    $ pre-commit install

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ to make sure you stay up-to-date with our repository:
     git merge upstream/main
 
 
-Intalling project requirements
+Installing project requirements
 ==============================
 
 This repository has the ``requirements.txt`` and the ``requirements-dev.txt``
@@ -83,10 +83,25 @@ Install development requirements
   $ pipenv install -d
 
 
+Running checks with pre-commit:
+
+The pre-commit tool is installed as part of the development requirements.
+
+To automatically run checks before you commit your changes you should run:
+
+.. code:: shell
+
+    $ make precommit
+
+This will install the git hook scripts for the first time, it will update to the
+latest versions of the hooks and run the pre-commit tool.
+Now ``pre-commit`` will run automatically on ``git commit``.
+
+
 Running API development
 =======================
 
-Runing the API locally
+Running the API locally
 
 .. code:: shell
 
@@ -102,7 +117,7 @@ See Makefile for more options
 Tests
 =====
 
-We use `Tox <ttps://tox.wiki/en/latest/>`_ to manage running the tests.
+We use `Tox <https://tox.wiki/en/latest/>`_ to manage running the tests.
 
 Running tests
 
@@ -137,16 +152,3 @@ Updating requirements files from Pipenv
 .. code:: shell
 
   $ make requirements
-
-
-Installing & enabling pre-commit
-================================
-
-The pre-commit tool is installed as part of the development requirements.
-
-To automatically run checks before you commit your changes you should install
-the git hook scripts with **pre-commit**:
-
-.. code:: shell
-
-    $ pre-commit install

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,108 +1,114 @@
 -i https://pypi.org/simple
 alabaster==0.7.12
-attrs==22.1.0 ; python_version >= '3.5'
-babel==2.10.3 ; python_version >= '3.6'
+attrs==22.1.0; python_version >= '3.5'
+babel==2.10.3; python_version >= '3.6'
 black==22.10.0
-certifi==2022.9.24 ; python_version >= '3.6'
+certifi==2022.9.24; python_version >= '3.6'
 cffi==1.15.1
-charset-normalizer==2.1.1 ; python_full_version >= '3.6.0'
-click==8.1.3 ; python_version >= '3.7'
+cfgv==3.3.1; python_full_version >= '3.6.1'
+charset-normalizer==2.1.1; python_version >= '3.6'
+click==8.1.3; python_version >= '3.7'
 coverage==6.5.0
 cryptography==38.0.1
 distlib==0.3.6
-docutils==0.17.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-filelock==3.8.0 ; python_version >= '3.7'
+docutils==0.17.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+filelock==3.8.0; python_version >= '3.7'
 flake8==5.0.4
-idna==3.4 ; python_version >= '3.5'
-imagesize==1.4.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-importlib-metadata==5.0.0 ; python_version < '3.10'
+identify==2.5.6; python_version >= '3.7'
+idna==3.4; python_version >= '3.5'
+imagesize==1.4.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+importlib-metadata==5.0.0; python_version < '3.10'
 iniconfig==1.1.1
 isort==5.10.1
-jinja2==3.1.2 ; python_version >= '3.7'
-jsonschema==4.16.0 ; python_version >= '3.7'
+jinja2==3.1.2; python_version >= '3.7'
+jsonschema==4.16.0; python_version >= '3.7'
 m2r==0.2.1
-markdown-it-py==2.1.0 ; python_version >= '3.7'
-markupsafe==2.1.1 ; python_version >= '3.7'
-mccabe==0.7.0 ; python_version >= '3.6'
-mdit-py-plugins==0.3.1 ; python_version >= '3.7'
-mdurl==0.1.2 ; python_version >= '3.7'
+markdown-it-py==2.1.0; python_version >= '3.7'
+markupsafe==2.1.1; python_version >= '3.7'
+mccabe==0.7.0; python_version >= '3.6'
+mdit-py-plugins==0.3.1; python_version >= '3.7'
+mdurl==0.1.2; python_version >= '3.7'
 mistune==0.8.4
 mypy-extensions==0.4.3
 myst-parser==0.18.1
-packaging==21.3 ; python_version >= '3.6'
-pathspec==0.10.1 ; python_version >= '3.7'
-platformdirs==2.5.2 ; python_version >= '3.7'
-pluggy==1.0.0 ; python_version >= '3.6'
+nodeenv==1.7.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
+packaging==21.3; python_version >= '3.6'
+pathspec==0.10.1; python_version >= '3.7'
+platformdirs==2.5.2; python_version >= '3.7'
+pluggy==1.0.0; python_version >= '3.6'
+pre-commit==2.20.0
 pretend==1.0.9
-py==1.11.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-pycodestyle==2.9.1 ; python_version >= '3.6'
+py==1.11.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+pycodestyle==2.9.1; python_version >= '3.6'
 pycparser==2.21
-pyflakes==2.5.0 ; python_version >= '3.6'
-pygments==2.13.0 ; python_version >= '3.6'
-pyparsing==3.0.9 ; python_full_version >= '3.6.8'
-pyrsistent==0.18.1 ; python_version >= '3.7'
+pyflakes==2.5.0; python_version >= '3.6'
+pygments==2.13.0; python_version >= '3.6'
+pyparsing==3.0.9; python_full_version >= '3.6.8'
+pyrsistent==0.18.1; python_version >= '3.7'
 pytest==7.1.3
 pytz==2022.5
-pyyaml==6.0 ; python_version >= '3.6'
-requests==2.28.1 ; python_version >= '3.7' and python_version < '4'
-six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pyyaml==6.0; python_version >= '3.6'
+requests==2.28.1; python_version >= '3.7' and python_full_version < '4.0.0'
+setuptools==65.5.0; python_version >= '3.7'
+six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 snowballstemmer==2.2.0
 sphinx==5.3.0
 sphinx-rtd-theme==1.0.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0
-sphinxcontrib-httpdomain==1.8.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+sphinxcontrib-httpdomain==1.8.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-openapi==0.7.0
 sphinxcontrib-plantuml==0.24
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-tomli==2.0.1 ; python_full_version < '3.11.0a7'
+toml==0.10.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
+tomli==2.0.1; python_full_version < '3.11.0a7'
 tox==3.26.0
-typing-extensions==4.4.0 ; python_version < '3.10'
-urllib3==1.26.12 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
-virtualenv==20.16.5 ; python_version >= '3.6'
+typing-extensions==4.4.0; python_version < '3.10'
+urllib3==1.26.12; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_full_version < '4.0.0'
+virtualenv==20.16.5; python_version >= '3.6'
 voluptuous==0.13.1
-zipp==3.9.0 ; python_version >= '3.7'
-amqp==5.1.1 ; python_version >= '3.6'
-anyio==3.6.2 ; python_full_version >= '3.6.2'
-async-timeout==4.0.2 ; python_version >= '3.6'
+zipp==3.10.0; python_version >= '3.7'
+amqp==5.1.1; python_version >= '3.6'
+anyio==3.6.2; python_full_version >= '3.6.2'
+async-timeout==4.0.2; python_version >= '3.6'
 bcrypt==4.0.1
 billiard==3.6.4.0
 celery==5.2.7
-click-didyoumean==0.3.0 ; python_full_version >= '3.6.2' and python_full_version < '4.0.0'
+click-didyoumean==0.3.0; python_full_version >= '3.6.2' and python_full_version < '4.0.0'
 click-plugins==1.1.1
 click-repl==0.2.0
 configobj==5.0.6
-deprecated==1.2.13 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-dnspython==2.2.1 ; python_version >= '3.6' and python_version < '4.0'
+deprecated==1.2.13; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+dnspython==2.2.1; python_version >= '3.6' and python_full_version < '4.0.0'
 dynaconf==3.1.11
-ecdsa==0.18.0 ; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
-email-validator==1.3.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+ecdsa==0.18.0; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
+email-validator==1.3.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 fastapi==0.85.1
 fastapi-users[sqlalchemy]==10.2.0
 fastapi-users-db-sqlalchemy==4.0.3
-greenlet==1.1.3.post0 ; python_version >= '3' and platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
-h11==0.14.0 ; python_version >= '3.7'
+greenlet==1.1.3.post0; python_version >= '3' and platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
+h11==0.14.0; python_version >= '3.7'
 hvac==1.0.2
-kombu==5.2.4 ; python_version >= '3.7'
+kombu==5.2.4; python_version >= '3.7'
 makefun==1.15.0
 passlib[bcrypt]==1.7.4
-prompt-toolkit==3.0.31 ; python_full_version >= '3.6.2'
+prompt-toolkit==3.0.31; python_full_version >= '3.6.2'
 pyasn1==0.4.8
-pydantic==1.10.2 ; python_version >= '3.7'
+pydantic==1.10.2; python_version >= '3.7'
 pyhcl==0.4.4
-pyjwt[crypto]==2.5.0 ; python_version >= '3.7'
+pyjwt[crypto]==2.5.0; python_version >= '3.7'
 python-jose==3.3.0
 python-multipart==0.0.5
 redis==4.3.4
-rsa==4.9 ; python_version >= '3.6' and python_version < '4'
-sniffio==1.3.0 ; python_version >= '3.7'
+rsa==4.9; python_version >= '3.6' and python_full_version < '4.0.0'
+sniffio==1.3.0; python_version >= '3.7'
 sqlalchemy==1.4.42
-starlette==0.20.4 ; python_version >= '3.7'
+starlette==0.20.4; python_version >= '3.7'
 types-cryptography==3.3.23.1
 uvicorn==0.19.0
-vine==5.0.0 ; python_version >= '3.6'
+vine==5.0.0; python_version >= '3.6'
 wcwidth==0.2.5
-wrapt==1.14.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+wrapt==1.14.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,56 +1,56 @@
 -i https://pypi.org/simple
-amqp==5.1.1 ; python_version >= '3.6'
-anyio==3.6.2 ; python_full_version >= '3.6.2'
-async-timeout==4.0.2 ; python_version >= '3.6'
+amqp==5.1.1; python_version >= '3.6'
+anyio==3.6.2; python_full_version >= '3.6.2'
+async-timeout==4.0.2; python_version >= '3.6'
 bcrypt==4.0.1
 billiard==3.6.4.0
 celery==5.2.7
-certifi==2022.9.24 ; python_version >= '3.6'
+certifi==2022.9.24; python_version >= '3.6'
 cffi==1.15.1
-charset-normalizer==2.1.1 ; python_full_version >= '3.6.0'
-click==8.1.3 ; python_version >= '3.7'
-click-didyoumean==0.3.0 ; python_full_version >= '3.6.2' and python_full_version < '4.0.0'
+charset-normalizer==2.1.1; python_version >= '3.6'
+click==8.1.3; python_version >= '3.7'
+click-didyoumean==0.3.0; python_full_version >= '3.6.2' and python_full_version < '4.0.0'
 click-plugins==1.1.1
 click-repl==0.2.0
 configobj==5.0.6
 cryptography==38.0.1
-deprecated==1.2.13 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-dnspython==2.2.1 ; python_version >= '3.6' and python_version < '4.0'
+deprecated==1.2.13; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+dnspython==2.2.1; python_version >= '3.6' and python_full_version < '4.0.0'
 dynaconf==3.1.11
-ecdsa==0.18.0 ; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
-email-validator==1.3.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+ecdsa==0.18.0; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
+email-validator==1.3.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 fastapi==0.85.1
 fastapi-users[sqlalchemy]==10.2.0
 fastapi-users-db-sqlalchemy==4.0.3
-greenlet==1.1.3.post0 ; python_version >= '3' and platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
-h11==0.14.0 ; python_version >= '3.7'
+greenlet==1.1.3.post0; python_version >= '3' and platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
+h11==0.14.0; python_version >= '3.7'
 hvac==1.0.2
-idna==3.4 ; python_version >= '3.5'
-kombu==5.2.4 ; python_version >= '3.7'
+idna==3.4; python_version >= '3.5'
+kombu==5.2.4; python_version >= '3.7'
 makefun==1.15.0
-packaging==21.3 ; python_version >= '3.6'
+packaging==21.3; python_version >= '3.6'
 passlib[bcrypt]==1.7.4
-prompt-toolkit==3.0.31 ; python_full_version >= '3.6.2'
+prompt-toolkit==3.0.31; python_full_version >= '3.6.2'
 pyasn1==0.4.8
 pycparser==2.21
-pydantic==1.10.2 ; python_version >= '3.7'
+pydantic==1.10.2; python_version >= '3.7'
 pyhcl==0.4.4
-pyjwt[crypto]==2.5.0 ; python_version >= '3.7'
-pyparsing==3.0.9 ; python_full_version >= '3.6.8'
+pyjwt[crypto]==2.5.0; python_version >= '3.7'
+pyparsing==3.0.9; python_full_version >= '3.6.8'
 python-jose==3.3.0
 python-multipart==0.0.5
 pytz==2022.5
 redis==4.3.4
-requests==2.28.1 ; python_version >= '3.7' and python_version < '4'
-rsa==4.9 ; python_version >= '3.6' and python_version < '4'
-six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-sniffio==1.3.0 ; python_version >= '3.7'
+requests==2.28.1; python_version >= '3.7' and python_full_version < '4.0.0'
+rsa==4.9; python_version >= '3.6' and python_full_version < '4.0.0'
+six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+sniffio==1.3.0; python_version >= '3.7'
 sqlalchemy==1.4.42
-starlette==0.20.4 ; python_version >= '3.7'
+starlette==0.20.4; python_version >= '3.7'
 types-cryptography==3.3.23.1
-typing-extensions==4.4.0 ; python_version < '3.10'
-urllib3==1.26.12 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
+typing-extensions==4.4.0; python_version < '3.10'
+urllib3==1.26.12; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_full_version < '4.0.0'
 uvicorn==0.19.0
-vine==5.0.0 ; python_version >= '3.6'
+vine==5.0.0; python_version >= '3.6'
 wcwidth==0.2.5
-wrapt==1.14.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+wrapt==1.14.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py39,py310,requirements,lint,test,test-docs
 
 [flake8]
-exclude = ownca/__init__.py,venv,.venv,settings.py,.git,.tox,dist,docs,*lib/python*,*egg,build,tools
+exclude = repository_service_tuf_api/__init__.py,venv,.venv,settings.py,.git,.tox,dist,docs,*lib/python*,*egg,build,tools
 
 [testenv]
 setenv =
@@ -17,10 +17,11 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-dev.txt
 
 [testenv:lint]
+deps = pre-commit
 commands =
-    flake8
-    isort -l79 --profile black --check --diff .
-    black -l79 --check --diff .
+    pre-commit run flake8 --all-files --show-diff-on-failure
+    pre-commit run isort --all-files --show-diff-on-failure
+    pre-commit run black --all-files --show-diff-on-failure
 
 [testenv:test-docs]
 allowlist_externals =
@@ -60,8 +61,8 @@ allowlist_externals =
     bash
 commands =
     pipenv --version
-    bash -c 'diff requirements.txt <(pipenv requirements)'
-    bash -c 'diff requirements-dev.txt <(pipenv requirements --dev)'
+    bash -c 'diff -w requirements.txt <(pipenv requirements)'
+    bash -c 'diff -w requirements-dev.txt <(pipenv requirements --dev)'
 
 [gh-actions]
 python =


### PR DESCRIPTION
In this PR, we add the pre-commit tool to
improve the Software Development Lifecycle
of the project by automatically running checks
(mainly linting & formatting) before one commits their changes.

- Specifically:
* flake8, isort and black were adjusted in tox to run as a pre-commit hooks
* Additionally, added hooks were:
 - the check-added-large-files - prevents giant files from being committed
 - end-of-file-fixer - ensures that a file is either empty or ends with one newline
 - trailing-whitespace - trims trailing whitespace
 - check-yaml - checks yaml files for parseable syntax
* we added a local hook with pre-commit that calls tox to check if `make requirements` is up-to-date

- The Pipfile dev-packages were updated to include pre-commit.

- We updated the README.md with how to install and enable pre-commit.

- We ran `make requirements`.

- Fix tox requirements check failing.