### PR TITLE
build: add workflow for updating python dependencies

### DIFF
--- a/.github/workflows/update-python-deps.yml
+++ b/.github/workflows/update-python-deps.yml
@@ -1,0 +1,35 @@
+name: Update Python dependencies
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * *"
+jobs:
+  update-dep:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-versions: ["3.10"]
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
+        with:
+          python-version: ${{ matrix.python-versions }}
+      - name: Install prerequisites
+        run: |
+          pip install tox pipenv
+      - name: Update dependencies
+        run: |
+          pipenv update -d
+          make requirements
+      - name: Run tests
+        run: |
+          make tests
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@b4d51739f96fca8047ad065eccef63442d8e99f7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "build: Update Python dependencies"
+          title: "build: Update Python dependencies"
+          body: >
+            The following PR updates the Python dependencies and generates new pipfile and requirements file.
+          labels: report, automated pr, python

--- a/Pipfile
+++ b/Pipfile
@@ -41,4 +41,4 @@ mistune = "==0.8.4"
 myst-parser = "*"
 
 [requires]
-python_version = "3.9"
+python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b0cc5fb9bf134b06397185496cfdb6a9806da373acacc108bbd25384b49d5bdc"
+            "sha256": "6e42176c857d5acf13e7fb0c61cad771c4bb4b9ab9f41a91a2f4af537c0f9b8a"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.10"
         },
         "sources": [
             {
@@ -370,7 +370,7 @@
                 "sha256:f7d20c3267385236b4ce54575cc8e9f43e7673fc761b069c820097092e318e3b",
                 "sha256:fe7c51f8a2ab616cb34bc33d810c887e89117771028e1e3d3b77ca25ddeace04"
             ],
-            "markers": "python_version >= '3' and platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.1.3.post0"
         },
         "h11": {
@@ -659,7 +659,7 @@
                 "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
                 "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
             ],
-            "markers": "python_version < '3.10'",
+            "markers": "python_version >= '3.7'",
             "version": "==4.4.0"
         },
         "urllib3": {
@@ -1010,6 +1010,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.17.1"
         },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:2e3c3fc1538a094aab74fad52d6c33fc94de3dfee3ee01f187c0e0c72aec5337",
+                "sha256:9086a4a21ef9b31c72181c77c040a074ba0889ee56a7b289ff0afb0d97655f96"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.0.0rc9"
+        },
         "filelock": {
             "hashes": [
                 "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc",
@@ -1304,11 +1312,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7",
-                "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"
+                "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71",
+                "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"
             ],
             "index": "pypi",
-            "version": "==7.1.3"
+            "version": "==7.2.0"
         },
         "pytz": {
             "hashes": [
@@ -1493,7 +1501,7 @@
                 "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
                 "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
             ],
-            "markers": "python_version < '3.10'",
+            "markers": "python_version >= '3.7'",
             "version": "==4.4.0"
         },
         "urllib3": {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ coverage==6.5.0
 cryptography==38.0.1
 distlib==0.3.6
 docutils==0.17.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+exceptiongroup==1.0.0rc9 ; python_version < '3.11'
 filelock==3.8.0 ; python_version >= '3.7'
 flake8==5.0.4
 idna==3.4 ; python_version >= '3.5'
@@ -41,7 +42,7 @@ pyflakes==2.5.0 ; python_version >= '3.6'
 pygments==2.13.0 ; python_version >= '3.6'
 pyparsing==3.0.9 ; python_full_version >= '3.6.8'
 pyrsistent==0.18.1 ; python_version >= '3.7'
-pytest==7.1.3
+pytest==7.2.0
 pytz==2022.5
 pyyaml==6.0 ; python_version >= '3.6'
 requests==2.28.1 ; python_version >= '3.7' and python_version < '4'
@@ -60,7 +61,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 tomli==2.0.1 ; python_full_version < '3.11.0a7'
 tox==3.26.0
-typing-extensions==4.4.0 ; python_version < '3.10'
+typing-extensions==4.4.0 ; python_version >= '3.7'
 urllib3==1.26.12 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
 virtualenv==20.16.5 ; python_version >= '3.6'
 voluptuous==0.13.1
@@ -83,7 +84,7 @@ email-validator==1.3.0 ; python_version >= '2.7' and python_version not in '3.0,
 fastapi==0.85.1
 fastapi-users[sqlalchemy]==10.2.0
 fastapi-users-db-sqlalchemy==4.0.3
-greenlet==1.1.3.post0 ; python_version >= '3' and platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
+greenlet==1.1.3.post0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 h11==0.14.0 ; python_version >= '3.7'
 hvac==1.0.2
 kombu==5.2.4 ; python_version >= '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ email-validator==1.3.0 ; python_version >= '2.7' and python_version not in '3.0,
 fastapi==0.85.1
 fastapi-users[sqlalchemy]==10.2.0
 fastapi-users-db-sqlalchemy==4.0.3
-greenlet==1.1.3.post0 ; python_version >= '3' and platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))
+greenlet==1.1.3.post0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 h11==0.14.0 ; python_version >= '3.7'
 hvac==1.0.2
 idna==3.4 ; python_version >= '3.5'
@@ -48,7 +48,7 @@ sniffio==1.3.0 ; python_version >= '3.7'
 sqlalchemy==1.4.42
 starlette==0.20.4 ; python_version >= '3.7'
 types-cryptography==3.3.23.1
-typing-extensions==4.4.0 ; python_version < '3.10'
+typing-extensions==4.4.0 ; python_version >= '3.7'
 urllib3==1.26.12 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
 uvicorn==0.19.0
 vine==5.0.0 ; python_version >= '3.6'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,py310,requirements,lint,test,test-docs
+envlist = py310,requirements,lint,test,test-docs
 
 [flake8]
 exclude = ownca/__init__.py,venv,.venv,settings.py,.git,.tox,dist,docs,*lib/python*,*egg,build,tools
@@ -65,5 +65,4 @@ commands =
 
 [gh-actions]
 python =
-    3.9: py39,pep8,lint,requirements,test,test-docs
     3.10: py310,pep8,lint,requirements,test,test-docs


### PR DESCRIPTION
The following PR adds a dedicated workflow for updating Python dependencies.

Details:
* Runs daily
* If another one is already opened, it doesn't create a new one, instead, it updates it.

Related to https://github.com/vmware/repository-service-tuf/issues/84

Fixes https://github.com/vmware/repository-service-tuf-api/issues/130 too

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>