### PR TITLE
chore: add github templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,44 @@
+name: 🪲 Bug
+description: File a bug report
+title: "Bug: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Please provide a detailed description of the bug. Also tell us, what did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: What steps did you take?
+      description: Please provide a clear and concise description steps that can be used to reproduce the problem.
+    validations:
+      required: false
+  - type: textarea
+    id: expectations
+    attributes:
+      label: What behavior did you expect?
+      description: Please provide a description of what was expected.
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this bug, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: I need help
+    url: https://github.com/vmware/repository-service-tuf
+    about: If you have questions or need help

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,31 @@
+name: 📃 Other
+description: File a general report
+title: "Other: "
+labels: ["other"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this general report!
+  - type: textarea
+    id: description
+    attributes:
+      label: What do you want to share with us?
+      description: Use this template in case none of other ones match your intentions. Please provide a detailed description of what you want to share with us.
+    validations:
+      required: true
+  - type: textarea
+    id: other
+    attributes:
+      label: References
+      description: Please provide any references that are related to your report.
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this report, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,38 @@
+name: 🔨 Task
+description: File a task report
+title: "Task: "
+labels: ["task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this task report!
+  - type: textarea
+    id: description
+    attributes:
+      label: What is the task about?
+      description: Please provide a detailed description of the task.
+    validations:
+      required: true
+  - type: textarea
+    id: feature
+    attributes:
+      label: Parent feature
+      description: Please provide a reference to the parent feature that this task is about.
+    validations:
+      required: false
+  - type: textarea
+    id: other
+    attributes:
+      label: References
+      description: Please provide any other references that are related to this task.
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this report, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE/pr.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/pr.yml
@@ -1,0 +1,43 @@
+name: 📦 Pull request
+description: Create a new pull request
+labels: ["pr"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this pull request!
+  - type: textarea
+    id: description
+    attributes:
+      label: What is the PR about?
+      description: Please fill in the fields below to submit a pull request. The more information that is provided, the better.
+    validations:
+      required: true
+  - type: textarea
+    id: issue
+    attributes:
+      label: Fixes #
+      description: Please reference the issue this PR fixes.
+    validations:
+      required: false
+  - type: checkboxes
+    attributes:
+      label: Types of changes
+      options:
+        - label: Bug fix (non-breaking change which fixes an issue)
+        - label: New feature (non-breaking change which adds functionality)
+        - label: Breaking change (fix or feature that would cause existing functionality to not work as expected).
+  - type: checkboxes
+    attributes:
+      label: Additional requirements
+      options:
+        - label: Tests have been added for the bug fix or new feature
+        - label: Docs have been added for the bug fix or new feature
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this PR, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.rst)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true


### PR DESCRIPTION
The following PR adds templates for both issues and pull requests.

It is based on the beta feature of Github to use yml issue forms which contribute to a better user experience - ref. [github/creating-issue-forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms)

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>