### PR TITLE
Updated the pipeline file to Limit the dev tag Docker Images.

### DIFF
--- a/.github/workflows/publish_docker_dev.yml
+++ b/.github/workflows/publish_docker_dev.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches:
       - 'main'
+    paths:
+      - '.github/workflows/publish_docker_dev.yml'
+      - 'app.py'
+      - 'entrypoint.sh'
+      - 'Dockerfile'
+      - 'requirements**'
+      - 'repository_service_tuf_api/**'
+      - 'setup.py'
+
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Update the pipeline file to Limit the dev tag Docker Images only for relevant changes.
It reduces the number of builds for specific changes.

Closes #116 

Edited by @kairoaraujo 

Signed-off-by: Luiz Andrade <luiz.pandradejr@gmail.com>