### PR TITLE
build: functional tests before release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,9 +7,16 @@ on:
       - v*
 
 jobs:
+  functional-latest:
+    uses: vmware/repository-service-tuf/.github/workflows/functional.yml@main
+    with:
+      worker_version: latest
+      api_version: dev
+      cli_version: latest
+
   release:
     runs-on: ubuntu-latest
-
+    needs: functional-latest
     steps:
     - name: Checkout release tag
       uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
When a release is trigged, it uses the functional tests from vmware/repository-service-tuf (umbrella repository).

The release is build/published if the functional tests is ok

Closes #162

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>