### PR TITLE
Remove redundant "read:targets" scope

### DIFF
--- a/docs/source/guide/api/swagger.json
+++ b/docs/source/guide/api/swagger.json
@@ -508,7 +508,7 @@
                     "scope": {
                         "title": "Scope",
                         "type": "string",
-                        "description": "Add scopes separeted by space. Available scopes: `read:bootstrap`, `read:settings`, `read:targets`, `read:tasks`, `read:token`, `write:bootstrap`, `write:targets`, `write:token`, `delete:targets`"
+                        "description": "Add scopes separeted by space. Available scopes: `read:bootstrap`, `read:settings`, `read:tasks`, `read:token`, `write:bootstrap`, `write:targets`, `write:token`, `delete:targets`"
                     },
                     "expires": {
                         "title": "Expires",
@@ -1364,7 +1364,6 @@
                         "scopes": [
                             "read:bootstrap",
                             "read:settings",
-                            "read:targets",
                             "read:tasks",
                             "read:token",
                             "write:bootstrap",
@@ -1954,7 +1953,6 @@
                             "enum": [
                                 "read:bootstrap",
                                 "read:settings",
-                                "read:targets",
                                 "read:token",
                                 "write:targets"
                             ],
@@ -2116,7 +2114,6 @@
                 "flows": {
                     "password": {
                         "scopes": {
-                            "read:targets": "Read (GET) targets",
                             "read:bootstrap": "Read (GET) bootstrap",
                             "read:settings": "Read (GET) settings",
                             "read:tasks": "Read (GET) tasks",

--- a/repository_service_tuf_api/__init__.py
+++ b/repository_service_tuf_api/__init__.py
@@ -30,7 +30,6 @@ logging.basicConfig(
 class SCOPES_NAMES(Enum):
     read_bootstrap = "read:bootstrap"
     read_settings = "read:settings"
-    read_targets = "read:targets"
     read_tasks = "read:tasks"
     read_token = "read:token"
     write_bootstrap = "write:bootstrap"
@@ -40,7 +39,6 @@ class SCOPES_NAMES(Enum):
 
 
 SCOPES = {
-    SCOPES_NAMES.read_targets.value: "Read (GET) targets",
     SCOPES_NAMES.read_bootstrap.value: "Read (GET) bootstrap",
     SCOPES_NAMES.read_settings.value: "Read (GET) settings",
     SCOPES_NAMES.read_tasks.value: "Read (GET) tasks",

--- a/repository_service_tuf_api/token.py
+++ b/repository_service_tuf_api/token.py
@@ -85,7 +85,6 @@ class TokenRequestPayload(BaseModel):
         Literal[
             SCOPES_NAMES.read_bootstrap.value,
             SCOPES_NAMES.read_settings.value,
-            SCOPES_NAMES.read_targets.value,
             SCOPES_NAMES.read_token.value,
             SCOPES_NAMES.write_targets.value,
         ]

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -109,7 +109,7 @@ class TestPostTargets:
         token_payload = {
             "username": "admin",
             "password": "secret",
-            "scope": "",
+            "scope": "read:settings",
         }
         token = test_client.post(token_url, data=token_payload)
         headers = {

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -109,7 +109,7 @@ class TestPostTargets:
         token_payload = {
             "username": "admin",
             "password": "secret",
-            "scope": "read:targets",
+            "scope": "",
         }
         token = test_client.post(token_url, data=token_payload)
         headers = {

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -75,7 +75,7 @@ class TestGetTask:
         token_payload = {
             "username": "admin",
             "password": "secret",
-            "scope": "",
+            "scope": "read:settings",
         }
         token = test_client.post(token_url, data=token_payload)
         headers = {

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -75,7 +75,7 @@ class TestGetTask:
         token_payload = {
             "username": "admin",
             "password": "secret",
-            "scope": ("read:targets " "read:settings " "read:token "),
+            "scope": "",
         }
         token = test_client.post(token_url, data=token_payload)
         headers = {

--- a/tests/unit/api/test_token.py
+++ b/tests/unit/api/test_token.py
@@ -145,7 +145,7 @@ class TestPostToken:
                 id=1213,
                 username="read_user",
                 password="test",
-                scopes=[],
+                scopes=[Scope("read:settings")],
             )
         )
         monkeypatch.setattr(

--- a/tests/unit/api/test_token.py
+++ b/tests/unit/api/test_token.py
@@ -145,7 +145,7 @@ class TestPostToken:
                 id=1213,
                 username="read_user",
                 password="test",
-                scopes=[Scope("read:targets")],
+                scopes=[],
             )
         )
         monkeypatch.setattr(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -28,7 +28,6 @@ def token_headers(test_client):
         "password": "secret",
         "scope": (
             "write:targets "
-            "read:targets "
             "write:bootstrap "
             "read:bootstrap "
             "read:settings "


### PR DESCRIPTION
Remove redundant "read:targets" scope.

Closes https://github.com/vmware/repository-service-tuf-api/issues/177

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>