### PR TITLE
Fix security issue with Tokens when empty scope

### DIFF
--- a/docs/source/guide/api/swagger.json
+++ b/docs/source/guide/api/swagger.json
@@ -490,7 +490,8 @@
                 "title": "Body_post_api_v1_token__post",
                 "required": [
                     "username",
-                    "password"
+                    "password",
+                    "scope"
                 ],
                 "type": "object",
                 "properties": {
@@ -500,13 +501,14 @@
                     },
                     "password": {
                         "title": "Password",
-                        "type": "string"
+                        "type": "string",
+                        "format": "password",
+                        "writeOnly": true
                     },
                     "scope": {
                         "title": "Scope",
                         "type": "string",
-                        "description": "Add scopes separeted by space. Default user scopes. Users might not have all scopes. Available scopes: read:bootstrap read:settings read:targets read:tasks read:token write:bootstrap write:targets write:token delete:targets",
-                        "default": ""
+                        "description": "Add scopes separeted by space. Available scopes: `read:bootstrap`, `read:settings`, `read:targets`, `read:tasks`, `read:token`, `write:bootstrap`, `write:targets`, `write:token`, `delete:targets`"
                     },
                     "expires": {
                         "title": "Expires",

--- a/repository_service_tuf_api/token.py
+++ b/repository_service_tuf_api/token.py
@@ -10,7 +10,7 @@ from fastapi import Depends, HTTPException, Query, status
 from fastapi.param_functions import Form
 from fastapi.security import OAuth2PasswordBearer, SecurityScopes
 from jose import JWTError, jwt
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, SecretStr, ValidationError
 
 from repository_service_tuf_api import SCOPES, SCOPES_NAMES, SECRET_KEY, db
 from repository_service_tuf_api.users.crud import bcrypt, get_user_by_username
@@ -22,14 +22,12 @@ class TokenRequestForm:
     def __init__(
         self,
         username: str = Form(),
-        password: str = Form(),
-        scope: Optional[str] = Form(
-            default="",
+        password: SecretStr = Form(),
+        scope: str = Form(
             description=(
                 "Add scopes separeted by space. "
-                "Default user scopes. Users might not have all scopes. "
                 "Available scopes: "
-                f"{' '.join([scope.value for scope in SCOPES_NAMES])}"
+                f"{', '.join([f'`{scope.value}`' for scope in SCOPES_NAMES])}"
             ),
         ),
         expires: Optional[int] = Form(
@@ -37,7 +35,7 @@ class TokenRequestForm:
         ),
     ):
         self.username = username
-        self.password = password
+        self.password = password.get_secret_value()
         self.scope = scope.split()
         self.expires = expires
 

--- a/tests/unit/api/test_token.py
+++ b/tests/unit/api/test_token.py
@@ -174,15 +174,7 @@ class TestPostToken:
         }
         assert mocked_bcrypt.checkpw.calls == [pretend.call(b"test", "test")]
 
-    def test_post_with_empty_scope(self, monkeypatch, test_client):
-        mocked_datetime = pretend.stub(
-            utcnow=pretend.call_recorder(
-                lambda: datetime(2019, 6, 16, 9, 5, 00, 355186)
-            )
-        )
-        monkeypatch.setattr(
-            "repository_service_tuf_api.token.datetime", mocked_datetime
-        )
+    def test_post_with_empty_scope(self, test_client):
         url = "/api/v1/token/"
         token_data = {
             "username": "admin",
@@ -193,15 +185,7 @@ class TestPostToken:
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.json()["detail"]["error"] == "scope '''' forbidden"
 
-    def test_post_with_missing_scope(self, monkeypatch, test_client):
-        mocked_datetime = pretend.stub(
-            utcnow=pretend.call_recorder(
-                lambda: datetime(2019, 6, 16, 9, 5, 00, 355186)
-            )
-        )
-        monkeypatch.setattr(
-            "repository_service_tuf_api.token.datetime", mocked_datetime
-        )
+    def test_post_with_missing_scope(self, test_client):
         url = "/api/v1/token/"
         token_data = {
             "username": "admin",

--- a/tests/unit/api/test_token.py
+++ b/tests/unit/api/test_token.py
@@ -173,3 +173,40 @@ class TestPostToken:
             "detail": {"error": "scope 'write:targets' forbidden"}
         }
         assert mocked_bcrypt.checkpw.calls == [pretend.call(b"test", "test")]
+
+    def test_post_with_empty_scope(self, monkeypatch, test_client):
+        mocked_datetime = pretend.stub(
+            utcnow=pretend.call_recorder(
+                lambda: datetime(2019, 6, 16, 9, 5, 00, 355186)
+            )
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.token.datetime", mocked_datetime
+        )
+        url = "/api/v1/token/"
+        token_data = {
+            "username": "admin",
+            "password": "secret",
+            "scope": "''",
+        }
+        response = test_client.post(url, data=token_data)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json()["detail"]["error"] == "scope '''' forbidden"
+
+    def test_post_with_missing_scope(self, monkeypatch, test_client):
+        mocked_datetime = pretend.stub(
+            utcnow=pretend.call_recorder(
+                lambda: datetime(2019, 6, 16, 9, 5, 00, 355186)
+            )
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.token.datetime", mocked_datetime
+        )
+        url = "/api/v1/token/"
+        token_data = {
+            "username": "admin",
+            "password": "secret",
+            "scope": None,
+        }
+        response = test_client.post(url, data=token_data)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY


### PR DESCRIPTION
The initial design for the built-in Authentication/Authorization was based on multiple users with scopes.
Users, after authentication, would receive a token with all its defined scopes.

Authentication and Authorization are not core components of RSTUF. We simplified this design to have only one user (admin), and the admin can generate Tokens with specific Scopes.
During this design change, we did not change the user fetching all scopes if the scope is empty/None.
We even want to allow the user to disable the
Authentication/Authorization layer (see
https://github.com/vmware/repository-service-tuf/issues/41) and use their  Authentication/Authorization layer.

- Add scope as required
- Add tests to avoid regression
- Hide password in the swagger try out
- Gives a clearer view of the scopes in the documentation (swagger)

Closes #175

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>