### PR TITLE
fix: generate tokens with invalid expires

### DIFF
--- a/docs/source/guide/api/swagger.json
+++ b/docs/source/guide/api/swagger.json
@@ -512,6 +512,7 @@
                     },
                     "expires": {
                         "title": "Expires",
+                        "minimum": 1.0,
                         "type": "integer",
                         "description": "Expiration in hours. Default: 1 hour",
                         "default": 1
@@ -1961,6 +1962,7 @@
                     },
                     "expires": {
                         "title": "Expires",
+                        "minimum": 1.0,
                         "type": "integer",
                         "description": "In hour(s)"
                     }

--- a/repository_service_tuf_api/token.py
+++ b/repository_service_tuf_api/token.py
@@ -31,7 +31,9 @@ class TokenRequestForm:
             ),
         ),
         expires: Optional[int] = Form(
-            default=1, description="Expiration in hours. Default: 1 hour"
+            default=1,
+            description="Expiration in hours. Default: 1 hour",
+            ge=1,
         ),
     ):
         self.username = username
@@ -89,7 +91,7 @@ class TokenRequestPayload(BaseModel):
             SCOPES_NAMES.write_targets.value,
         ]
     ]
-    expires: int = Field(description="In hour(s)")
+    expires: int = Field(description="In hour(s)", ge=1)
 
     class Config:
         example = {

--- a/tests/unit/api/test_token.py
+++ b/tests/unit/api/test_token.py
@@ -194,3 +194,78 @@ class TestPostToken:
         }
         response = test_client.post(url, data=token_data)
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_post_with_expires_0(self, test_client):
+        url = "/api/v1/token/"
+        token_data = {
+            "username": "admin",
+            "password": "secret",
+            "scope": ["write:targets"],
+            "expires": 0,
+        }
+        response = test_client.post(url, data=token_data)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "ensure this value is greater than or equal to 1"
+        )
+
+    def test_post_with_expires_negative(self, test_client):
+        url = "/api/v1/token/"
+        token_data = {
+            "username": "admin",
+            "password": "secret",
+            "scope": ["write:targets"],
+            "expires": -25,
+        }
+        response = test_client.post(url, data=token_data)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "ensure this value is greater than or equal to 1"
+        )
+
+    def test_post_new_with_expires_0(self, test_client, token_headers):
+        url = "/api/v1/token/new/"
+        payload = {
+            "scopes": ["write:targets"],
+            "expires": 0,
+        }
+        response = test_client.post(url, headers=token_headers, json=payload)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "ensure this value is greater than or equal to 1"
+        )
+
+    def test_post_new_with_expires_negative(self, test_client, token_headers):
+        url = "/api/v1/token/new/"
+        payload = {
+            "scopes": ["write:targets"],
+            "expires": -31,
+        }
+        response = test_client.post(url, headers=token_headers, json=payload)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "ensure this value is greater than or equal to 1"
+        )
+
+    def test_post_new_with_expires_missing(self, test_client, token_headers):
+        url = "/api/v1/token/new/"
+        payload = {
+            "scopes": ["write:targets"],
+        }
+        response = test_client.post(url, headers=token_headers, json=payload)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.json()["detail"][0]["msg"] == "field required"
+
+    def test_post_new_with_expires_none(self, test_client, token_headers):
+        url = "/api/v1/token/new/"
+        payload = {"scopes": ["write:targets"], "expires": None}
+        response = test_client.post(url, headers=token_headers, json=payload)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "none is not an allowed value"
+        )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -33,6 +33,7 @@ def token_headers(test_client):
             "read:settings "
             "read:token "
             "read:tasks "
+            "write:token "
             "delete:targets "
         ),
     }


### PR DESCRIPTION
This fixes the possibility to generate tokens with invalid expires.

The expire is define in hours and it fixes when someone request a token with expires equal 0 or negative.

Adds also UT to avoid regression.

Closes #188

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>