### PR TITLE
Fix the generation of tokens with specific scopes and disallow token with empty scope

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.4.0
   hooks:
   - id: check-added-large-files
   - id: end-of-file-fixer
@@ -10,7 +10,7 @@ repos:
   - id: check-yaml
     files: '.github/'
 - repo: https://github.com/pycqa/flake8
-  rev: '5.0.4'
+  rev: '6.0.0'
   hooks:
   - id: flake8
     exclude: repository_service_tuf_api/__init__.py|venv|.venv|setting.py|.git|.tox|dist|docs|/*lib/python*|/*egg|build|tools

--- a/docs/source/guide/api/swagger.json
+++ b/docs/source/guide/api/swagger.json
@@ -1949,13 +1949,16 @@
                 "properties": {
                     "scopes": {
                         "title": "Scopes",
+                        "minItems": 1,
                         "type": "array",
                         "items": {
                             "enum": [
                                 "read:bootstrap",
                                 "read:settings",
+                                "read:tasks",
                                 "read:token",
-                                "write:targets"
+                                "write:targets",
+                                "delete:targets"
                             ],
                             "type": "string"
                         }

--- a/repository_service_tuf_api/token.py
+++ b/repository_service_tuf_api/token.py
@@ -87,8 +87,10 @@ class TokenRequestPayload(BaseModel):
         Literal[
             SCOPES_NAMES.read_bootstrap.value,
             SCOPES_NAMES.read_settings.value,
+            SCOPES_NAMES.read_tasks.value,
             SCOPES_NAMES.read_token.value,
             SCOPES_NAMES.write_targets.value,
+            SCOPES_NAMES.delete_targets.value,
         ]
     ]
     expires: int = Field(description="In hour(s)", ge=1)

--- a/repository_service_tuf_api/token.py
+++ b/repository_service_tuf_api/token.py
@@ -92,7 +92,7 @@ class TokenRequestPayload(BaseModel):
             SCOPES_NAMES.write_targets.value,
             SCOPES_NAMES.delete_targets.value,
         ]
-    ]
+    ] = Field(min_items=1)
     expires: int = Field(description="In hour(s)", ge=1)
 
     class Config:

--- a/tests/unit/api/test_token.py
+++ b/tests/unit/api/test_token.py
@@ -104,6 +104,20 @@ class TestPostToken:
         assert response.status_code == status.HTTP_200_OK
         assert "access_token" in response.json()
 
+    def test_post_new_with_empty_scope(self, test_client, token_headers):
+        url = "/api/v1/token/new/"
+        payload = {
+            "scopes": [],
+            "expires": 1,
+        }
+
+        response = test_client.post(url, headers=token_headers, json=payload)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "ensure this value has at least 1 items"
+        )
+
     def test_post_without_expires(self, monkeypatch, test_client):
         mocked_datetime = pretend.stub(
             utcnow=pretend.call_recorder(

--- a/tests/unit/api/test_token.py
+++ b/tests/unit/api/test_token.py
@@ -86,38 +86,6 @@ class TestPostToken:
         assert response.status_code == status.HTTP_200_OK
         assert "access_token" in response.json()
 
-    def test_post_new(self, test_client, token_headers):
-        url = "/api/v1/token/new/"
-        payload = {
-            "scopes": [
-                "read:bootstrap",
-                "read:settings",
-                "read:tasks",
-                "read:token",
-                "write:targets",
-                "delete:targets",
-            ],
-            "expires": 1,
-        }
-
-        response = test_client.post(url, headers=token_headers, json=payload)
-        assert response.status_code == status.HTTP_200_OK
-        assert "access_token" in response.json()
-
-    def test_post_new_with_empty_scope(self, test_client, token_headers):
-        url = "/api/v1/token/new/"
-        payload = {
-            "scopes": [],
-            "expires": 1,
-        }
-
-        response = test_client.post(url, headers=token_headers, json=payload)
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-        assert (
-            response.json()["detail"][0]["msg"]
-            == "ensure this value has at least 1 items"
-        )
-
     def test_post_without_expires(self, monkeypatch, test_client):
         mocked_datetime = pretend.stub(
             utcnow=pretend.call_recorder(
@@ -258,6 +226,38 @@ class TestPostToken:
         assert (
             response.json()["detail"][0]["msg"]
             == "ensure this value is greater than or equal to 1"
+        )
+
+    def test_post_new(self, test_client, token_headers):
+        url = "/api/v1/token/new/"
+        payload = {
+            "scopes": [
+                "read:bootstrap",
+                "read:settings",
+                "read:tasks",
+                "read:token",
+                "write:targets",
+                "delete:targets",
+            ],
+            "expires": 1,
+        }
+
+        response = test_client.post(url, headers=token_headers, json=payload)
+        assert response.status_code == status.HTTP_200_OK
+        assert "access_token" in response.json()
+
+    def test_post_new_with_empty_scope(self, test_client, token_headers):
+        url = "/api/v1/token/new/"
+        payload = {
+            "scopes": [],
+            "expires": 1,
+        }
+
+        response = test_client.post(url, headers=token_headers, json=payload)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "ensure this value has at least 1 items"
         )
 
     def test_post_new_with_expires_0(self, test_client, token_headers):

--- a/tests/unit/api/test_token.py
+++ b/tests/unit/api/test_token.py
@@ -260,6 +260,32 @@ class TestPostToken:
             == "ensure this value has at least 1 items"
         )
 
+    def test_post_new_with_scopes_with_empty_string(
+        self, test_client, token_headers
+    ):
+        url = "/api/v1/token/new/"
+        payload = {
+            "scopes": [""],
+            "expires": 1,
+        }
+
+        response = test_client.post(url, headers=token_headers, json=payload)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert "unexpected value" in response.json()["detail"][0]["msg"]
+
+    def test_post_new_with_scopes_with_invalid_scope(
+        self, test_client, token_headers
+    ):
+        url = "/api/v1/token/new/"
+        payload = {
+            "scopes": ["invalid"],
+            "expires": 1,
+        }
+
+        response = test_client.post(url, headers=token_headers, json=payload)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert "unexpected value" in response.json()["detail"][0]["msg"]
+
     def test_post_new_with_expires_0(self, test_client, token_headers):
         url = "/api/v1/token/new/"
         payload = {

--- a/tests/unit/api/test_token.py
+++ b/tests/unit/api/test_token.py
@@ -77,9 +77,30 @@ class TestPostToken:
         token_data = {
             "username": "admin",
             "password": "secret",
-            "scope": "write:targets",
+            "scope": (
+                "read:bootstrap read:settings read:tasks read:token "
+                "write:targets delete:targets"
+            ),
         }
         response = test_client.post(url, data=token_data)
+        assert response.status_code == status.HTTP_200_OK
+        assert "access_token" in response.json()
+
+    def test_post_new(self, test_client, token_headers):
+        url = "/api/v1/token/new/"
+        payload = {
+            "scopes": [
+                "read:bootstrap",
+                "read:settings",
+                "read:tasks",
+                "read:token",
+                "write:targets",
+                "delete:targets",
+            ],
+            "expires": 1,
+        }
+
+        response = test_client.post(url, headers=token_headers, json=payload)
         assert response.status_code == status.HTTP_200_OK
         assert "access_token" in response.json()
 


### PR DESCRIPTION
Fix a bug where the generation of a token with a scope containing `read:tasks` or `delete:targets` lead to an error.
Also, disallow the generation of a token where the `scopes` field is an empty list.

I added regression tests for both changes.

Close #185 #187 

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>
