### PR TITLE
feat: Add to the API the last_update for tasks

### DIFF
--- a/docs/source/guide/api/swagger.json
+++ b/docs/source/guide/api/swagger.json
@@ -2082,7 +2082,7 @@
                             "file2.tar.gz"
                         ],
                         "task_id": "06ee6db3cbab4b26be505352c2f2e2c3",
-                        "last_update": "2022-12-01T10:28:35.305616"
+                        "last_update": "2022-12-01T12:10:00.578086"
                     },
                     "message": "New Target(s) successfully submitted."
                 }

--- a/docs/source/guide/api/swagger.json
+++ b/docs/source/guide/api/swagger.json
@@ -1434,7 +1434,8 @@
                 "title": "ResponseData",
                 "required": [
                     "targets",
-                    "task_id"
+                    "task_id",
+                    "last_update"
                 ],
                 "type": "object",
                 "properties": {
@@ -1448,6 +1449,11 @@
                     "task_id": {
                         "title": "Task Id",
                         "type": "string"
+                    },
+                    "last_update": {
+                        "title": "Last Update",
+                        "type": "string",
+                        "format": "date-time"
                     }
                 }
             },
@@ -2075,7 +2081,8 @@
                             "file1.tar.gz",
                             "file2.tar.gz"
                         ],
-                        "task_id": "06ee6db3cbab4b26be505352c2f2e2c3"
+                        "task_id": "06ee6db3cbab4b26be505352c2f2e2c3",
+                        "last_update": "2022-12-01T10:28:35.305616"
                     },
                     "message": "New Target(s) successfully submitted."
                 }

--- a/repository_service_tuf_api/targets.py
+++ b/repository_service_tuf_api/targets.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import json
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from fastapi import HTTPException, status
@@ -18,6 +19,7 @@ from repository_service_tuf_api.metadata import (
 class ResponseData(BaseModel):
     targets: List[str]
     task_id: str
+    last_update: datetime
 
 
 class Response(BaseModel):
@@ -33,6 +35,7 @@ class Response(BaseModel):
             "data": {
                 "targets": ["file1.tar.gz", "file2.tar.gz"],
                 "task_id": "06ee6db3cbab4b26be505352c2f2e2c3",
+                "last_update": datetime.now(),
             },
             "message": "New Target(s) successfully submitted.",
         }
@@ -116,6 +119,7 @@ def post(payload: AddPayload) -> Response:
     data = {
         "targets": [target.path for target in payload.targets],
         "task_id": task_id,
+        "last_update": datetime.now(),
     }
     return Response(data=data, message="Target(s) successfully submitted.")
 
@@ -147,6 +151,7 @@ def delete(payload: DeletePayload) -> Response:
     data = {
         "targets": payload.targets,
         "task_id": task_id,
+        "last_update": datetime.now(),
     }
     return Response(
         data=data, message="Remove Target(s) successfully submitted."

--- a/repository_service_tuf_api/targets.py
+++ b/repository_service_tuf_api/targets.py
@@ -35,7 +35,7 @@ class Response(BaseModel):
             "data": {
                 "targets": ["file1.tar.gz", "file2.tar.gz"],
                 "task_id": "06ee6db3cbab4b26be505352c2f2e2c3",
-                "last_update": datetime.now(),
+                "last_update": "2022-12-01T12:10:00.578086",
             },
             "message": "New Target(s) successfully submitted.",
         }

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 VMware Inc
 #
 # SPDX-License-Identifier: MIT
-
+import datetime
 import json
 from uuid import uuid4
 
@@ -32,13 +32,20 @@ class TestPostTargets:
             "repository_service_tuf_api.targets.get_task_id",
             lambda: fake_task_id,
         )
-
+        fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+        fake_datetime = pretend.stub(
+            now=pretend.call_recorder(lambda: fake_time)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.datetime", fake_datetime
+        )
         response = test_client.post(url, json=payload, headers=token_headers)
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.json() == {
             "data": {
                 "targets": ["file1.tar.gz", "file2.tar.gz"],
                 "task_id": fake_task_id,
+                "last_update": "2019-06-16T09:05:01",
             },
             "message": "Target(s) successfully submitted.",
         }
@@ -152,6 +159,13 @@ class TestDeleteTargets:
             "repository_service_tuf_api.targets.get_task_id",
             lambda: fake_task_id,
         )
+        fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+        fake_datetime = pretend.stub(
+            now=pretend.call_recorder(lambda: fake_time)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.datetime", fake_datetime
+        )
 
         response = test_client.delete(url, json=payload, headers=token_headers)
         assert response.status_code == status.HTTP_202_ACCEPTED
@@ -159,6 +173,7 @@ class TestDeleteTargets:
             "data": {
                 "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"],
                 "task_id": fake_task_id,
+                "last_update": "2019-06-16T09:05:01",
             },
             "message": "Remove Target(s) successfully submitted.",
         }


### PR DESCRIPTION
It adds to the API responses for HTTP CODE 202 (received), used by tasks, the field `last_update`.

This field helps to the requesters manage the tasks based on date time

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>