### PR TITLE
fix: consistent snapshot field not in the task

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ to make sure you stay up-to-date with our repository:
 
 
 Installing project requirements
-==============================
+===============================
 
 This repository has the ``requirements.txt`` and the ``requirements-dev.txt``
 files to help build your virtual environment.

--- a/docs/source/guide/api/swagger.json
+++ b/docs/source/guide/api/swagger.json
@@ -1694,6 +1694,10 @@
                             "$ref": "#/components/schemas/TUFKeys"
                         }
                     },
+                    "consistent_snapshot": {
+                        "title": "Consistent Snapshot",
+                        "type": "boolean"
+                    },
                     "roles": {
                         "title": "Roles",
                         "type": "object",

--- a/repository_service_tuf_api/bootstrap.py
+++ b/repository_service_tuf_api/bootstrap.py
@@ -77,6 +77,7 @@ class TUFSigned(BaseModel):
     spec_version: str
     expires: str
     keys: Optional[Dict[str, TUFKeys]]
+    consistent_snapshot: Optional[bool]
     roles: Optional[
         Dict[
             Literal[


### PR DESCRIPTION
The TUF Root Metadata `consistent_snasphot: True` was not sent in the task.
The `1.root.json` in the Storage Backend was not saved with the field.

It doesn't impact the client, unless the client uses this file as the initial `root.json`.

Minor: Fix `README.rst` subtitle format.