### PR TITLE
fix: custom redis configuration for the container

### DIFF
--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -78,7 +78,7 @@ Redis Server DB number for Result Backend (tasks). Default: 0
 
 Important: It should use the same db id as used by RSTUF Workers.
 
-#### (Optional) `RSTUF_REDIS_SERVER_DB_SETTINGS`
+#### (Optional) `RSTUF_REDIS_SERVER_DB_REPO_SETTINGS`
 
 Redis Server DB number for repository settings. Default: 1
 

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -82,7 +82,7 @@ Important: It should use the same db id as used by RSTUF Workers.
 
 Redis Server DB number for repository settings. Default: 1
 
-This settings are shared to Repository Workers
+These settings are shared with the repository workers
 (``repository-service-tuf-worker``) to have dynamic configuration.
 
 Important: It should use the same db id as used by RSTUF Workers.

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -71,7 +71,7 @@ A specific database can be chosen in the URL. Default: 0
 
 Example: `redis://redis/1`
 
-Important: The workers have to use the same port for the db result.
+Important: The workers have to use the same db id for the db result.
 
 #### (Optional) `RSTUF_REDIS_SERVER_PORT`
 

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -67,16 +67,16 @@ Example: `amqp://guest:guest@rabbitmq:5672`
 #### (Required) `RSTUF_REDIS_SERVER`
 
 Redis server address.
-A specific database can be chosen in the URL. Default: 0
-
-Example: `redis://redis/1`
-
-Important: The workers have to use the same db id for the db result.
 
 #### (Optional) `RSTUF_REDIS_SERVER_PORT`
 
 Redis Server port number. Default: 6379
 
+#### (Optional) `RSTUF_REDIS_SERVER_DB_RESULT`
+
+Redis Server DB number for Result Backend (tasks). Default: 0
+
+Important: It should use the same db id as used by RSTUF Workers.
 
 #### (Optional) `RSTUF_REDIS_SERVER_DB_SETTINGS`
 
@@ -84,6 +84,8 @@ Redis Server DB number for repository settings. Default: 1
 
 This settings are shared to Repository Workers
 (``repository-service-tuf-worker``) to have dynamic configuration.
+
+Important: It should use the same db id as used by RSTUF Workers.
 
 #### (Required) `SECRETS_RSTUF_TOKEN_KEY`
 

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -67,25 +67,22 @@ Example: `amqp://guest:guest@rabbitmq:5672`
 #### (Required) `RSTUF_REDIS_SERVER`
 
 Redis server address.
+A specific database can be chosen in the URL. Default: 0
 
-The result backend must to be compatible with Celery. See
-[Celery Task result backend settings](https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-result-backend-settings)
+Example: `redis://redis/1`
 
-Example: `redis://redis`
+Important: The workers have to use the same port for the db result.
 
 #### (Optional) `RSTUF_REDIS_SERVER_PORT`
 
 Redis Server port number. Default: 6379
 
-#### (Optional) `RSTUF_REDIS_SERVER_DB_RESULT`
 
-Redis Server DB number for Result Backend (tasks). Default: 0
-
-#### (Optional) `RSTUF_REDIS_SERVER_DB_REPO_SETTINGS`
+#### (Optional) `RSTUF_REDIS_SERVER_DB_SETTINGS`
 
 Redis Server DB number for repository settings. Default: 1
 
-This settings are shared accress the Repository Workers
+This settings are shared to Repository Workers
 (``repository-service-tuf-worker``) to have dynamic configuration.
 
 #### (Required) `SECRETS_RSTUF_TOKEN_KEY`

--- a/repository_service_tuf_api/__init__.py
+++ b/repository_service_tuf_api/__init__.py
@@ -64,8 +64,8 @@ settings_repository = Dynaconf(
     redis_enabled=True,
     redis={
         "host": settings.REDIS_SERVER.split("redis://")[1],
-        "port": settings.get("RSTUF_REDIS_SERVER_PORT", 6379),
-        "db": settings.get("RSTUF_REDIS_SERVER_DB_REPO_SETTINGS", 1),
+        "port": settings.get("REDIS_SERVER_PORT", 6379),
+        "db": settings.get("REDIS_SERVER_DB_SETTINGS", 1),
         "decode_responses": True,
     },
 )

--- a/repository_service_tuf_api/__init__.py
+++ b/repository_service_tuf_api/__init__.py
@@ -152,7 +152,11 @@ else:
 # Celery setup
 celery = Celery(__name__)
 celery.conf.broker_url = settings.BROKER_SERVER
-celery.conf.result_backend = settings.REDIS_SERVER
+celery.conf.result_backend = (
+    f"{settings.REDIS_SERVER}"
+    f":{settings.get('REDIS_SERVER_PORT', 6379)}"
+    f"/{settings.get('REDIS_SERVER_DB_RESULT', 0)}"
+)
 celery.conf.accept_content = ["json", "application/json"]
 celery.conf.task_serializer = "json"
 celery.conf.result_serializer = "json"

--- a/repository_service_tuf_api/__init__.py
+++ b/repository_service_tuf_api/__init__.py
@@ -65,7 +65,7 @@ settings_repository = Dynaconf(
     redis={
         "host": settings.REDIS_SERVER.split("redis://")[1],
         "port": settings.get("REDIS_SERVER_PORT", 6379),
-        "db": settings.get("REDIS_SERVER_DB_SETTINGS", 1),
+        "db": settings.get("REDIS_SERVER_DB_REPO_SETTINGS", 1),
         "decode_responses": True,
     },
 )
@@ -155,7 +155,7 @@ celery.conf.broker_url = settings.BROKER_SERVER
 celery.conf.result_backend = (
     f"{settings.REDIS_SERVER}"
     f":{settings.get('REDIS_SERVER_PORT', 6379)}"
-    f"/{settings.get('REDIS_SERVER_DB_RESULT', 0)}"
+    f"/{settings.get('REDIS_SERVER_DB_REPO_SETTINGS', 0)}"
 )
 celery.conf.accept_content = ["json", "application/json"]
 celery.conf.task_serializer = "json"


### PR DESCRIPTION
The current custom Redis configuration for the RSTUF API container doesn't work correctly.

- Fix wrong parsing for the Dynaconf configuration. The parser included the Dynaconf `envvar_prefix` `RSTUF`.
- Fix documentation
  - More detail about choosing a specific port for the celery task's backend result.

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>