### PR TITLE
Add an option to add task_id to target custom

### DIFF
--- a/docs/source/guide/api/swagger.json
+++ b/docs/source/guide/api/swagger.json
@@ -444,7 +444,8 @@
             "AddPayload": {
                 "title": "AddPayload",
                 "required": [
-                    "targets"
+                    "targets",
+                    "add_task_id_to_custom"
                 ],
                 "type": "object",
                 "properties": {
@@ -454,6 +455,10 @@
                         "items": {
                             "$ref": "#/components/schemas/Targets"
                         }
+                    },
+                    "add_task_id_to_custom": {
+                        "title": "Add Task Id To Custom",
+                        "type": "boolean"
                     }
                 },
                 "description": "POST method required Payload.",
@@ -483,7 +488,8 @@
                             },
                             "path": "file2.tar.gz"
                         }
-                    ]
+                    ],
+                    "add_task_id_to_custom": true
                 }
             },
             "Body_post_api_v1_token__post": {

--- a/docs/source/guide/api/swagger.json
+++ b/docs/source/guide/api/swagger.json
@@ -481,9 +481,6 @@
                                 "length": 630,
                                 "hashes": {
                                     "blake2b-256": "69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9"
-                                },
-                                "custom": {
-                                    "key": "value"
                                 }
                             },
                             "path": "file2.tar.gz"

--- a/repository_service_tuf_api/targets.py
+++ b/repository_service_tuf_api/targets.py
@@ -66,6 +66,7 @@ class AddPayload(BaseModel):
     """
 
     targets: List[Targets]
+    add_task_id_to_custom: bool
 
     class Config:
         with open("tests/data_examples/targets/payload.json") as f:
@@ -107,6 +108,21 @@ def post(payload: AddPayload) -> Response:
         )
 
     task_id = get_task_id()
+    if payload.add_task_id_to_custom:
+        new_targets: List[Targets] = []
+        for target in payload.targets:
+            if target.info.custom is None:
+                target.info.custom = {}
+
+            # Add task_id info in custom while keeping the old custom
+            target.info.custom = {
+                "added_by_task_id": task_id,
+                **target.info.custom,
+            }
+            new_targets.append(target)
+
+        payload.targets = new_targets
+
     repository_metadata.apply_async(
         kwargs={
             "action": "add_targets",

--- a/tests/data_examples/targets/payload.json
+++ b/tests/data_examples/targets/payload.json
@@ -15,8 +15,7 @@
                 "length": 630,
                 "hashes": {
                     "blake2b-256": "69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9"
-                },
-                "custom": {"key": "value"}
+                }
             },
             "path": "file2.tar.gz"
         }

--- a/tests/data_examples/targets/payload.json
+++ b/tests/data_examples/targets/payload.json
@@ -20,5 +20,6 @@
             },
             "path": "file2.tar.gz"
         }
-    ]
+    ],
+    "add_task_id_to_custom": true
 }

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -16,8 +16,6 @@ class TestPostTargets:
             f_data = f.read()
 
         payload = json.loads(f_data)
-        # Remove one"custom" in one of the targets to test this case
-        del payload["targets"][0]["info"]["custom"]
 
         mocked_repository_metadata = pretend.stub(
             apply_async=pretend.call_recorder(lambda *a, **kw: None)
@@ -120,11 +118,14 @@ class TestPostTargets:
             "message": "Target(s) successfully submitted.",
         }
 
+        # Add "custom" to the target where it's missing as it's loaded.
+        expected_payload = payload
+        expected_payload["targets"][1]["info"]["custom"] = None
         assert mocked_repository_metadata.apply_async.calls == [
             pretend.call(
                 kwargs={
                     "action": "add_targets",
-                    "payload": payload,
+                    "payload": expected_payload,
                 },
                 task_id=fake_task_id,
                 queue="metadata_repository",


### PR DESCRIPTION
Add an option which can be used for debugging to add the "task_id" of the process that adds the target into the "custom" attributes of all targets.
By default this option is enabled as it will add a small overhead, but can be quite useful for debugging in a bad scenario.

Closes https://github.com/vmware/repository-service-tuf-api/issues/57

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>