### PR TITLE
Simplify make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,6 @@ stop:
 clean:
 	$(MAKE) stop
 	docker-compose rm --force
-	rm -rf ./metadata/*
-	rm -rf ./keys/*
-	rm -rf ./database/*.sqlite
 	rm -rf ./data
 	rm -rf ./data_test
 


### PR DESCRIPTION
Remove some of the target folders that were deleted when "make clean" is called as those folders are not created when after a "make run-dev" call.

Connected with https://github.com/vmware/repository-service-tuf-worker/pull/158

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>