### PR TITLE
Remove python3.9 and add python3.11 ci build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-versions: [ "3.9", "3.10", ]
+        python-versions: [ "3.10", "3.11" ]
 
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310,requirements,lint,test,test-docs
+envlist = py310,py311,requirements,lint,test,test-docs
 
 [flake8]
 exclude = repository_service_tuf_api/__init__.py,venv,.venv,settings.py,.git,.tox,dist,docs,*lib/python*,*egg,build,tools
@@ -67,3 +67,4 @@ commands =
 [gh-actions]
 python =
     3.10: py310,pep8,lint,requirements,test,test-docs
+    3.11: py311,pep8,lint,requirements,test,test-docs


### PR DESCRIPTION
I noticed we run build for python3.9 when we say we support only python3.10 onwards.
That's why it seemed unnecessary that we are testing for python3.9.

On the other hand, python 3.11 was introduced back in October 2022 and we can directly add support for it.

Related to:
- https://github.com/vmware/repository-service-tuf-worker/pull/162
- https://github.com/vmware/repository-service-tuf-cli/pull/172

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>