### PR TITLE
fix: add_task_id_to_custom feature as optional

### DIFF
--- a/docs/source/guide/api/swagger.json
+++ b/docs/source/guide/api/swagger.json
@@ -444,8 +444,7 @@
             "AddPayload": {
                 "title": "AddPayload",
                 "required": [
-                    "targets",
-                    "add_task_id_to_custom"
+                    "targets"
                 ],
                 "type": "object",
                 "properties": {
@@ -485,8 +484,7 @@
                             },
                             "path": "file2.tar.gz"
                         }
-                    ],
-                    "add_task_id_to_custom": true
+                    ]
                 }
             },
             "Body_post_api_v1_token__post": {

--- a/tests/data_examples/targets/payload.json
+++ b/tests/data_examples/targets/payload.json
@@ -19,6 +19,5 @@
             },
             "path": "file2.tar.gz"
         }
-    ],
-    "add_task_id_to_custom": true
+    ]
 }

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -50,24 +50,11 @@ class TestPostTargets:
             },
             "message": "Target(s) successfully submitted.",
         }
-        # Add task_id info into custom as it will be done in the post function
-        expected_payload = {"targets": [], "add_task_id_to_custom": True}
-        for target in payload["targets"]:
-            if target["info"].get("custom") is None:
-                target["info"]["custom"] = {}
-
-            # Add task_id info in custom while keeping the old custom
-            target["info"]["custom"] = {
-                "added_by_task_id": fake_task_id,
-                **target["info"]["custom"],
-            }
-            expected_payload["targets"].append(target)
-
         assert mocked_repository_metadata.apply_async.calls == [
             pretend.call(
                 kwargs={
                     "action": "add_targets",
-                    "payload": expected_payload,
+                    "payload": payload,
                 },
                 task_id=fake_task_id,
                 queue="metadata_repository",
@@ -75,7 +62,7 @@ class TestPostTargets:
             )
         ]
 
-    def test_post_without_add_task_id_to_custom(
+    def test_post_with_add_task_id_to_custom(
         self, monkeypatch, test_client, token_headers
     ):
         url = "/api/v1/targets/"
@@ -107,6 +94,10 @@ class TestPostTargets:
         monkeypatch.setattr(
             "repository_service_tuf_api.targets.datetime", fake_datetime
         )
+
+        # enable to add task id to custom metadata field
+        payload["add_task_id_to_custom"] = True
+
         response = test_client.post(url, json=payload, headers=token_headers)
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.json() == {
@@ -118,14 +109,80 @@ class TestPostTargets:
             "message": "Target(s) successfully submitted.",
         }
 
-        # Add "custom" to the target where it's missing as it's loaded.
-        expected_payload = payload
-        expected_payload["targets"][1]["info"]["custom"] = None
+        # Add task_id info into custom as it will be done in the post function
+        expected_payload = {"targets": [], "add_task_id_to_custom": True}
+        for target in payload["targets"]:
+            if target["info"].get("custom") is None:
+                target["info"]["custom"] = {}
+
+            # Add task_id info in custom while keeping the old custom
+            target["info"]["custom"] = {
+                "added_by_task_id": fake_task_id,
+                **target["info"]["custom"],
+            }
+            expected_payload["targets"].append(target)
         assert mocked_repository_metadata.apply_async.calls == [
             pretend.call(
                 kwargs={
                     "action": "add_targets",
-                    "payload": expected_payload,
+                    "payload": payload,
+                },
+                task_id=fake_task_id,
+                queue="metadata_repository",
+                acks_late=True,
+            )
+        ]
+
+    def test_post_with_add_task_id_to_custom_false(
+        self, monkeypatch, test_client, token_headers
+    ):
+        url = "/api/v1/targets/"
+        with open("tests/data_examples/targets/payload.json") as f:
+            f_data = f.read()
+
+        payload = json.loads(f_data)
+
+        mocked_repository_metadata = pretend.stub(
+            apply_async=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.is_bootstrap_done",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.repository_metadata",
+            mocked_repository_metadata,
+        )
+        fake_task_id = uuid4().hex
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.get_task_id",
+            lambda: fake_task_id,
+        )
+        fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+        fake_datetime = pretend.stub(
+            now=pretend.call_recorder(lambda: fake_time)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.datetime", fake_datetime
+        )
+        # force disable to add task id to custom metadata field
+        payload["add_task_id_to_custom"] = False
+        response = test_client.post(url, json=payload, headers=token_headers)
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.json() == {
+            "data": {
+                "targets": ["file1.tar.gz", "file2.tar.gz"],
+                "task_id": fake_task_id,
+                "last_update": "2019-06-16T09:05:01",
+            },
+            "message": "Target(s) successfully submitted.",
+        }
+        assert mocked_repository_metadata.apply_async.calls == [
+            pretend.call(
+                kwargs={
+                    "action": "add_targets",
+                    "payload": payload,
                 },
                 task_id=fake_task_id,
                 queue="metadata_repository",


### PR DESCRIPTION
It fixes the `add_task_id_to_custom` as an optional feature.

- Change the `add_task_id_to_custom` as optional
- Change the logic case the option is missing to force as None
- Add a check if the option is True
- Increate the UT for the API feature

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>