### PR TITLE
add API endpoint `/api/v1/targets/publish`

### DIFF
--- a/docs/source/guide/api/swagger.json
+++ b/docs/source/guide/api/swagger.json
@@ -381,6 +381,39 @@
                 ]
             }
         },
+        "/api/v1/targets/publish/": {
+            "post": {
+                "tags": [
+                    "v1",
+                    "v1"
+                ],
+                "summary": "Submit a task to publish targets.Scope: write:targets",
+                "description": "Trigger a task to publish targets not yet published from the RSTUF Database",
+                "operationId": "post_publish_targets_api_v1_targets_publish__post",
+                "responses": {
+                    "202": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/repository_service_tuf_api__targets__Response"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "OAuth2PasswordBearer": [
+                            "write:targets"
+                        ]
+                    }
+                ]
+            }
+        },
         "/api/v1/task/": {
             "get": {
                 "tags": [

--- a/repository_service_tuf_api/api/targets.py
+++ b/repository_service_tuf_api/api/targets.py
@@ -48,3 +48,23 @@ def delete(
     _user=Security(validate_token, scopes=[SCOPES_NAMES.delete_targets.value]),
 ):
     return targets.delete(payload)
+
+
+@router.post(
+    "/publish/",
+    summary=(
+        "Submit a task to publish targets."
+        f"Scope: {SCOPES_NAMES.write_targets.value}"
+    ),
+    description=(
+        "Trigger a task to publish targets not yet published from the "
+        "RSTUF Database"
+    ),
+    response_model=targets.Response,
+    response_model_exclude_none=True,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def post_publish_targets(
+    _user=Security(validate_token, scopes=[SCOPES_NAMES.write_targets.value]),
+):
+    return targets.post_publish_targets()

--- a/repository_service_tuf_api/targets.py
+++ b/repository_service_tuf_api/targets.py
@@ -17,7 +17,7 @@ from repository_service_tuf_api.metadata import (
 
 
 class ResponseData(BaseModel):
-    targets: List[str]
+    targets: Optional[List[str]]
     task_id: str
     last_update: datetime
 
@@ -171,4 +171,27 @@ def delete(payload: DeletePayload) -> Response:
     }
     return Response(
         data=data, message="Remove Target(s) successfully submitted."
+    )
+
+
+def post_publish_targets() -> Response:
+    task_id = get_task_id()
+    repository_metadata.apply_async(
+        kwargs={
+            "action": "publish_targets",
+            "payload": None,
+        },
+        task_id=task_id,
+        queue="rstuf_internals",
+        acks_late=True,
+    )
+
+    data = {
+        "targets": None,
+        "task_id": task_id,
+        "last_update": datetime.now(),
+    }
+
+    return Response(
+        data=data, message="Publish targets successfully submitted."
     )

--- a/repository_service_tuf_api/targets.py
+++ b/repository_service_tuf_api/targets.py
@@ -17,7 +17,7 @@ from repository_service_tuf_api.metadata import (
 
 
 class ResponseData(BaseModel):
-    targets: Optional[List[str]]
+    targets: List[str]
     task_id: str
     last_update: datetime
 
@@ -187,7 +187,7 @@ def post_publish_targets() -> Response:
     )
 
     data = {
-        "targets": None,
+        "targets": [],
         "task_id": task_id,
         "last_update": datetime.now(),
     }

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -353,6 +353,7 @@ class TestPostTargetsPublish:
         assert response.status_code == status.HTTP_202_ACCEPTED
         assert response.json() == {
             "data": {
+                "targets": [],
                 "task_id": fake_task_id,
                 "last_update": "2019-06-16T09:05:01",
             },

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -18,7 +18,7 @@ class TestPostTargets:
         payload = json.loads(f_data)
 
         mocked_repository_metadata = pretend.stub(
-            apply_async=pretend.call_recorder(lambda *a, **kw: None)
+            apply_async=pretend.call_recorder(lambda **kw: None)
         )
         monkeypatch.setattr(
             "repository_service_tuf_api.targets.is_bootstrap_done",
@@ -72,7 +72,7 @@ class TestPostTargets:
         payload = json.loads(f_data)
 
         mocked_repository_metadata = pretend.stub(
-            apply_async=pretend.call_recorder(lambda *a, **kw: None)
+            apply_async=pretend.call_recorder(lambda **kw: None)
         )
         monkeypatch.setattr(
             "repository_service_tuf_api.targets.is_bootstrap_done",
@@ -219,7 +219,7 @@ class TestDeleteTargets:
             lambda: True,
         )
         mocked_repository_metadata = pretend.stub(
-            apply_async=pretend.call_recorder(lambda *a, **kw: None)
+            apply_async=pretend.call_recorder(lambda **kw: None)
         )
         monkeypatch.setattr(
             "repository_service_tuf_api.targets.repository_metadata",
@@ -331,7 +331,7 @@ class TestPostTargetsPublish:
         url = "/api/v1/targets/publish/"
 
         mocked_repository_metadata = pretend.stub(
-            apply_async=pretend.call_recorder(lambda *a, **kw: None)
+            apply_async=pretend.call_recorder(lambda **kw: None)
         )
         monkeypatch.setattr(
             "repository_service_tuf_api.targets.repository_metadata",

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -324,3 +324,48 @@ class TestDeleteTargets:
         assert response.json() == {
             "detail": {"error": "scope 'delete:targets' not allowed"}
         }
+
+
+class TestPostTargetsPublish:
+    def test_post_publish(self, monkeypatch, test_client, token_headers):
+        url = "/api/v1/targets/publish/"
+
+        mocked_repository_metadata = pretend.stub(
+            apply_async=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.repository_metadata",
+            mocked_repository_metadata,
+        )
+        fake_task_id = uuid4().hex
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.get_task_id",
+            lambda: fake_task_id,
+        )
+        fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+        fake_datetime = pretend.stub(
+            now=pretend.call_recorder(lambda: fake_time)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.datetime", fake_datetime
+        )
+        response = test_client.post(url, headers=token_headers)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.json() == {
+            "data": {
+                "task_id": fake_task_id,
+                "last_update": "2019-06-16T09:05:01",
+            },
+            "message": "Publish targets successfully submitted.",
+        }
+        assert mocked_repository_metadata.apply_async.calls == [
+            pretend.call(
+                kwargs={
+                    "action": "publish_targets",
+                    "payload": None,
+                },
+                task_id=fake_task_id,
+                queue="rstuf_internals",
+                acks_late=True,
+            )
+        ]


### PR DESCRIPTION
It will send to broker a task with the action `publish_targets` and return HTTP 202 and the task id (follows the same task request for add targets).

Closes #242

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>