### PR TITLE
Add publish targets option

### DIFF
--- a/docs/source/guide/api/swagger.json
+++ b/docs/source/guide/api/swagger.json
@@ -490,7 +490,15 @@
                     },
                     "add_task_id_to_custom": {
                         "title": "Add Task Id To Custom",
-                        "type": "boolean"
+                        "type": "boolean",
+                        "description": "Whether to add the id of the task in custom",
+                        "default": false
+                    },
+                    "publish_targets": {
+                        "title": "Publish Targets",
+                        "type": "boolean",
+                        "description": "Whether to publish the targets",
+                        "default": true
                     }
                 },
                 "description": "POST method required Payload.",
@@ -1366,6 +1374,12 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "publish_targets": {
+                        "title": "Publish Targets",
+                        "type": "boolean",
+                        "description": "Whether to publish the targets changes",
+                        "default": true
                     }
                 },
                 "description": "DELETE method required Payload.",

--- a/repository_service_tuf_api/targets.py
+++ b/repository_service_tuf_api/targets.py
@@ -66,7 +66,10 @@ class AddPayload(BaseModel):
     """
 
     targets: List[Targets]
-    add_task_id_to_custom: Optional[bool]
+    add_task_id_to_custom: Optional[bool] = Field(
+        default=False,
+        description="Whether to add the id of the task in custom",
+    )
     publish_targets: Optional[bool] = Field(
         default=True, description="Whether to publish the targets"
     )

--- a/repository_service_tuf_api/targets.py
+++ b/repository_service_tuf_api/targets.py
@@ -66,11 +66,11 @@ class AddPayload(BaseModel):
     """
 
     targets: List[Targets]
-    add_task_id_to_custom: Optional[bool] = Field(
+    add_task_id_to_custom: bool = Field(
         default=False,
         description="Whether to add the id of the task in custom",
     )
-    publish_targets: Optional[bool] = Field(
+    publish_targets: bool = Field(
         default=True, description="Whether to publish the targets"
     )
 
@@ -87,7 +87,7 @@ class DeletePayload(BaseModel):
     """
 
     targets: List[str]
-    publish_targets: Optional[bool] = Field(
+    publish_targets: bool = Field(
         default=True, description="Whether to publish the targets changes"
     )
 

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -132,6 +132,64 @@ class TestPostTargets:
             )
         ]
 
+    def test_post_publish_targets_false(
+        self, monkeypatch, test_client, token_headers
+    ):
+        url = "/api/v1/targets/"
+        with open("tests/data_examples/targets/payload.json") as f:
+            f_data = f.read()
+
+        payload = json.loads(f_data)
+
+        # Disable publish_targets
+        payload["publish_targets"] = False
+
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.is_bootstrap_done",
+            lambda: True,
+        )
+        fake_task_id = uuid4().hex
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.get_task_id",
+            lambda: fake_task_id,
+        )
+        fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+        fake_datetime = pretend.stub(
+            now=pretend.call_recorder(lambda: fake_time)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.datetime", fake_datetime
+        )
+        mocked_repository_metadata = pretend.stub(
+            apply_async=pretend.call_recorder(lambda **kw: None)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.repository_metadata",
+            mocked_repository_metadata,
+        )
+        response = test_client.post(url, json=payload, headers=token_headers)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        msg = "Target(s) successfully submitted. Publishing will be skipped."
+        assert response.json() == {
+            "data": {
+                "targets": ["file1.tar.gz", "file2.tar.gz"],
+                "task_id": fake_task_id,
+                "last_update": "2019-06-16T09:05:01",
+            },
+            "message": msg,
+        }
+        assert mocked_repository_metadata.apply_async.calls == [
+            pretend.call(
+                kwargs={
+                    "action": "add_targets",
+                    "payload": payload,
+                },
+                task_id=fake_task_id,
+                queue="metadata_repository",
+                acks_late=True,
+            )
+        ]
+
     def test_post_without_bootstrap(
         self, monkeypatch, test_client, token_headers
     ):
@@ -247,6 +305,66 @@ class TestDeleteTargets:
                 "last_update": "2019-06-16T09:05:01",
             },
             "message": "Remove Target(s) successfully submitted.",
+        }
+        assert mocked_repository_metadata.apply_async.calls == [
+            pretend.call(
+                kwargs={
+                    "action": "remove_targets",
+                    "payload": payload,
+                },
+                task_id=fake_task_id,
+                queue="metadata_repository",
+                acks_late=True,
+            )
+        ]
+
+    def test_delete_publish_targets_false(
+        self, monkeypatch, test_client, token_headers
+    ):
+        url = "/api/v1/targets/"
+
+        payload = {
+            "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"],
+            "publish_targets": False,
+        }
+
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.is_bootstrap_done",
+            lambda: True,
+        )
+        mocked_repository_metadata = pretend.stub(
+            apply_async=pretend.call_recorder(lambda **kw: None)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.repository_metadata",
+            mocked_repository_metadata,
+        )
+        fake_task_id = uuid4().hex
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.get_task_id",
+            lambda: fake_task_id,
+        )
+        fake_time = datetime.datetime(2019, 6, 16, 9, 5, 1)
+        fake_datetime = pretend.stub(
+            now=pretend.call_recorder(lambda: fake_time)
+        )
+        monkeypatch.setattr(
+            "repository_service_tuf_api.targets.datetime", fake_datetime
+        )
+
+        response = test_client.delete(url, json=payload, headers=token_headers)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        msg = (
+            "Remove Target(s) successfully submitted. "
+            + "Publishing will be skipped."
+        )
+        assert response.json() == {
+            "data": {
+                "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"],
+                "task_id": fake_task_id,
+                "last_update": "2019-06-16T09:05:01",
+            },
+            "message": msg,
         }
         assert mocked_repository_metadata.apply_async.calls == [
             pretend.call(

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -54,7 +54,11 @@ class TestPostTargets:
             pretend.call(
                 kwargs={
                     "action": "add_targets",
-                    "payload": payload,
+                    "payload": {
+                        **payload,
+                        "publish_targets": True,
+                        "add_task_id_to_custom": False,
+                    },
                 },
                 task_id=fake_task_id,
                 queue="metadata_repository",
@@ -124,7 +128,10 @@ class TestPostTargets:
             pretend.call(
                 kwargs={
                     "action": "add_targets",
-                    "payload": payload,
+                    "payload": {
+                        **payload,
+                        "publish_targets": True,
+                    },
                 },
                 task_id=fake_task_id,
                 queue="metadata_repository",
@@ -182,7 +189,7 @@ class TestPostTargets:
             pretend.call(
                 kwargs={
                     "action": "add_targets",
-                    "payload": payload,
+                    "payload": {**payload, "add_task_id_to_custom": False},
                 },
                 task_id=fake_task_id,
                 queue="metadata_repository",
@@ -269,7 +276,7 @@ class TestDeleteTargets:
         url = "/api/v1/targets/"
 
         payload = {
-            "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"]
+            "targets": ["file-v1.0.0_i683.tar.gz", "v0.4.1/file.tar.gz"],
         }
 
         monkeypatch.setattr(
@@ -310,7 +317,7 @@ class TestDeleteTargets:
             pretend.call(
                 kwargs={
                     "action": "remove_targets",
-                    "payload": payload,
+                    "payload": {**payload, "publish_targets": True},
                 },
                 task_id=fake_task_id,
                 queue="metadata_repository",

--- a/tox.ini
+++ b/tox.ini
@@ -42,8 +42,9 @@ commands_post =
 deps = -r{toxinidir}/docs/requirements.txt
 allowlist_externals =
     rm
+    plantuml
 commands =
-    plantuml -o ../source/_static/ -tpng docs/diagrams/*.puml
+    plantuml -Djava.awt.headless=true -o ../source/_static/ -tpng docs/diagrams/*.puml
     python -c "import app; app.export_swagger_json('docs/source/guide/api/swagger.json')"
 	sphinx-apidoc -f -o  docs/source/devel/ repository_service_tuf_api
 	sphinx-build -E -W -b html docs/source docs/build/html


### PR DESCRIPTION
Add an optional field called "publish_targets" in the add/remove
targets API calls. If no value is provided or it's set to true,
publishing of targets will happen the same as now: a subtask will
be started that on completion will have published the modified targets.
If it's set to false, publishing of the targets file changes won't be
published (meaning there won't be any changes in the metadata files
as well) until specifically requested with the newly introduced
API call "api/v1/targets/publish".

This feature is was originated in Task:
https://github.com/vmware/repository-service-tuf-worker/issues/175
discussion.

Additionally, give add_task_id_to_custom a default value.

Close https://github.com/vmware/repository-service-tuf-api/issues/248