### PR TITLE
Correct documentation for listening port of API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,11 +108,11 @@ Running the API locally
   $ make run-dev
 
 
-Open http://localhost:8000/ in your browser.
+Open http://localhost:80/ in your browser.
 
 Changes in the code will automatically update the service.
 
-See Makefile for more options
+See the `Makefile` for more options.
 
 Tests
 =====


### PR DESCRIPTION
The API listens on port 80 (http://localhost:80/), so we corrected the docs (they used to suggest
http://localhost:8000/).

- [x] check for other instances of `http://localhost:8000` in the repository
- [x] check for other instances of `http://localhost:8000` in the RSTUF Worker repository

Closes #233