### PR TITLE
Scope variable name reused in nested loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ dmypy.json
 
 # VScode settings folder
 .vscode
+
+# Pycharm settings folder
+.idea

--- a/repository_service_tuf_api/token.py
+++ b/repository_service_tuf_api/token.py
@@ -168,7 +168,7 @@ def post(token_data):
         )
 
     for scope in token_data.scope:
-        if scope not in [scope.name for scope in user.scopes]:
+        if scope not in [sc.name for sc in user.scopes]:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail={"error": f"scope '{scope}' forbidden"},


### PR DESCRIPTION
Fix the bug in which the scope variable name is reused in a nested loop