### PR TITLE
Flexible maintainers CD Workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,22 +1,63 @@
 name: CD
 
 on:
-  workflow_dispatch:
   push:
     tags:
-      - v*
+      - v*    
+  workflow_dispatch:      
+    inputs:
+      api_version:
+        description: "API Version"
+        default: "dev"
+        type: string
+        required: False
+      worker_version:
+        description: "Worker Version"
+        default: "latest"
+        type: string
+        required: False
+      cli_version:
+        description: "CLI Version"
+        default: "latest"
+        type: string
+        required: False
+
 
 jobs:
-  functional-latest:
+  set-component-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      api_version: ${{ steps.api_version.outputs.VERSION }}
+      worker_version: ${{ steps.worker_version.outputs.VERSION }}
+      cli_version: ${{ steps.cli_version.outputs.VERSION }}
+
+    steps:
+      - id: api_version
+        name: dynamic input api version
+        run: |
+          if [[ "${{ inputs.api_version }}" == "" ]]; then echo "VERSION=dev" >> $GITHUB_OUTPUT; else echo "VERSION=${{ inputs.api_version }}" >> $GITHUB_OUTPUT;fi
+
+      - id: worker_version
+        name: dynamic input worker version
+        run: |
+          if [[ "${{ inputs.worker_version }}" == "" ]]; then echo "VERSION=latest" >> $GITHUB_OUTPUT; else echo "VERSION=${{ inputs.worker_version }}" >> $GITHUB_OUTPUT;fi
+
+      - id: cli_version
+        name: dynamic input cli version
+        run: |
+          if [[ "${{ inputs.cli_version }}" == "" ]]; then echo "VERSION=latest" >> $GITHUB_OUTPUT; else echo "VERSION=${{ inputs.cli_version }}" >> $GITHUB_OUTPUT;fi
+
+  functional-tests:
+    needs: set-component-versions
     uses: vmware/repository-service-tuf/.github/workflows/functional.yml@main
     with:
-      worker_version: latest
-      api_version: dev
-      cli_version: latest
+      api_version: ${{ needs.set-component-versions.outputs.api_version }}   
+      worker_version: ${{ needs.set-component-versions.outputs.worker_version }}   
+      cli_version: ${{ needs.set-component-versions.outputs.cli_version }}   
 
   release:
     runs-on: ubuntu-latest
-    needs: functional-latest
+    needs: functional-tests
     steps:
     - name: Checkout release tag
       uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,9 +65,9 @@ jobs:
     - name: Add final tags
       run: |
         docker pull ghcr.io/vmware/repository-service-tuf-api:${{ github.sha }}
-        docker tag ghcr.io/vmware/repository-service-tuf-api:${{ github.sha }} ghcr.io/vmware/repository-service-tuf-api:latest
         docker tag ghcr.io/vmware/repository-service-tuf-api:${{ github.sha }} ghcr.io/vmware/repository-service-tuf-api:${{ github.ref_name }}
         docker push ghcr.io/vmware/repository-service-tuf-api:${{ github.ref_name }}
+        docker tag ghcr.io/vmware/repository-service-tuf-api:${{ github.sha }} ghcr.io/vmware/repository-service-tuf-api:latest
         docker push ghcr.io/vmware/repository-service-tuf-api:latest
 
     - name: Publish GitHub Release

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,14 +3,9 @@ name: CD
 on:
   push:
     tags:
-      - v*    
-  workflow_dispatch:      
+      - v*
+  workflow_dispatch:
     inputs:
-      api_version:
-        description: "API Version"
-        default: "dev"
-        type: string
-        required: False
       worker_version:
         description: "Worker Version"
         default: "latest"
@@ -24,7 +19,13 @@ on:
 
 
 jobs:
+  publish-container-image:
+    uses: vmware/repository-service-tuf/.github/workflows/publish_container.yml@kairoaraujo-flexible-cd
+    with:
+      image_version: ${{ github.ref_name }}
+
   set-component-versions:
+    needs: publish-container-image
     runs-on: ubuntu-latest
     outputs:
       api_version: ${{ steps.api_version.outputs.VERSION }}
@@ -32,11 +33,6 @@ jobs:
       cli_version: ${{ steps.cli_version.outputs.VERSION }}
 
     steps:
-      - id: api_version
-        name: dynamic input api version
-        run: |
-          if [[ "${{ inputs.api_version }}" == "" ]]; then echo "VERSION=dev" >> $GITHUB_OUTPUT; else echo "VERSION=${{ inputs.api_version }}" >> $GITHUB_OUTPUT;fi
-
       - id: worker_version
         name: dynamic input worker version
         run: |
@@ -51,29 +47,14 @@ jobs:
     needs: set-component-versions
     uses: vmware/repository-service-tuf/.github/workflows/functional.yml@main
     with:
-      api_version: ${{ needs.set-component-versions.outputs.api_version }}   
-      worker_version: ${{ needs.set-component-versions.outputs.worker_version }}   
-      cli_version: ${{ needs.set-component-versions.outputs.cli_version }}   
+      api_version: ${{ github.ref_name }}
+      worker_version: ${{ needs.set-component-versions.outputs.worker_version }}
+      cli_version: ${{ needs.set-component-versions.outputs.cli_version }}
 
   release:
     runs-on: ubuntu-latest
     needs: functional-tests
     steps:
-    - name: Checkout release tag
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      with:
-        ref: ${{ github.event.workflow_run.head_branch }}
-
-    - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
-      with:
-        python-version: '3.10'
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7
-
     - name: Login to GitHub Container Registry
       uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
       with:
@@ -81,27 +62,11 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    # Cannot use output type docker local and push. Build and export and caches
-    - name: Build and export
-      uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
-      with:
-        context: .
-        tags: |
-            ghcr.io/vmware/repository-service-tuf-api:latest
-            ghcr.io/vmware/repository-service-tuf-api:${{ github.ref_name }}
-        outputs: type=docker,dest=/tmp/repository-service-tuf-api_${{ github.ref_name }}.tar
-        cache-to: type=local,dest=/tmp/rstuf_api_cache
-
-    # Build and push using the local cache from above step
-    - name:  Build and push (using cache)
-      uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
-      with:
-        context: .
-        push: true
-        tags: |
-            ghcr.io/vmware/repository-service-tuf-api:latest
-            ghcr.io/vmware/repository-service-tuf-api:${{ github.ref_name }}
-        cache-from: type=local,src=/tmp/rstuf_api_cache
+    - name: Add final tags
+      run: |
+        docker pull ghcr.io/vmware/repository-service-tuf-api:${{ github.ref_name }}
+        docker tag ghcr.io/vmware/repository-service-tuf-api:${{ github.ref_name }} latest
+        docker push ghcr.io/vmware/repository-service-tuf-api:latest
 
     - name: Publish GitHub Release
       uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,9 +20,9 @@ on:
 
 jobs:
   publish-container-image:
-    uses: vmware/repository-service-tuf/.github/workflows/publish_container.yml@kairoaraujo-flexible-cd
+    uses: ./.github/workflows/publish_container.yml
     with:
-      image_version: ${{ github.ref_name }}
+      image_version: ${{ github.sha }}
 
   set-component-versions:
     needs: publish-container-image
@@ -47,7 +47,7 @@ jobs:
     needs: set-component-versions
     uses: vmware/repository-service-tuf/.github/workflows/functional.yml@main
     with:
-      api_version: ${{ github.ref_name }}
+      api_version: ${{ github.sha }}
       worker_version: ${{ needs.set-component-versions.outputs.worker_version }}
       cli_version: ${{ needs.set-component-versions.outputs.cli_version }}
 
@@ -64,8 +64,10 @@ jobs:
 
     - name: Add final tags
       run: |
-        docker pull ghcr.io/vmware/repository-service-tuf-api:${{ github.ref_name }}
-        docker tag ghcr.io/vmware/repository-service-tuf-api:${{ github.ref_name }} latest
+        docker pull ghcr.io/vmware/repository-service-tuf-api:${{ github.sha }}
+        docker tag ghcr.io/vmware/repository-service-tuf-api:${{ github.sha }} ghcr.io/vmware/repository-service-tuf-api:latest
+        docker tag ghcr.io/vmware/repository-service-tuf-api:${{ github.sha }} ghcr.io/vmware/repository-service-tuf-api:${{ github.ref_name }}
+        docker push ghcr.io/vmware/repository-service-tuf-api:${{ github.ref_name }}
         docker push ghcr.io/vmware/repository-service-tuf-api:latest
 
     - name: Publish GitHub Release

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       with:
         fetch-depth: 0
-        ref: ${{ input.image_version }}
+        ref: ${{ inputs.image_version }}
 
     - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
       with:
@@ -49,6 +49,6 @@ jobs:
         context: .
         push: true
         tags: |
-            ghcr.io/vmware/repository-service-tuf-api:${{ input.image_version }}
+            ghcr.io/vmware/repository-service-tuf-api:${{ inputs.image_version }}
         build-args: |
-          RELEASE_VERSION=${{ input.image_version }}
+          RELEASE_VERSION=${{ inputs.image_version }}

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -1,0 +1,54 @@
+name: Publish Container Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_version:
+        description: "Image version"
+        default: "dev"
+        type: string
+        required: False
+  workflow_call:
+    inputs:
+      image_version:
+        description: "Image version"
+        default: "dev"
+        type: string
+        required: False
+
+jobs:
+  publish_container_image:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      with:
+        fetch-depth: 0
+        ref: ${{ input.image_version }}
+
+    - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
+      with:
+        python-version: '3.10'
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+      with:
+        context: .
+        push: true
+        tags: |
+            ghcr.io/vmware/repository-service-tuf-api:${{ input.image_version }}
+        build-args: |
+          RELEASE_VERSION=${{ input.image_version }}

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -21,12 +21,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+    - name: Checkout release tag
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       with:
         fetch-depth: 0
         ref: ${{ inputs.image_version }}
 
-    - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
+    - name: Set default Python version
+      uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
       with:
         python-version: '3.10'
 


### PR DESCRIPTION
This PR introduces a change in the `cd.yml` Workflow.

We release our components versions using the tags `v*`
The process of release has two steps:
1. Run the functional tests (FT) using the component to be released `v*` tag (from `main` branch) against the latest releases of the components.
2. If the (FT) finishes successfully, the `cd.yml` releases the new Docker Image GitHub Registry and adds it to our Releases page in Github. (Python package in case of the CLI).

If step 1 fails, the release breaks the compatibility with the current release.

The problem we are solving is how to release a new version when it breaks the compatibility.

This PR adds the workflow dispatch option for releases.
The maintainers can now go to the Actions > CD > Run Workflow, choose the `v*` tag release, and specify the version of the components it is compatible with, including `dev` (main branch) to run the FT tests. 

Using the Workflow dispatcher process, the Maintainers should bump to a version that shows it is breaking compatibility and make it clear on the release page.
We have a [Release Process](https://repository-service-tuf.readthedocs.io/en/latest/devel/release.html#release-process) and we are not changing it, only adding the Workflow that allows those actions.