### PR TITLE
cd.yml: remove non-existing job output

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,7 +28,6 @@ jobs:
     needs: publish-container-image
     runs-on: ubuntu-latest
     outputs:
-      api_version: ${{ steps.api_version.outputs.VERSION }}
       worker_version: ${{ steps.worker_version.outputs.VERSION }}
       cli_version: ${{ steps.cli_version.outputs.VERSION }}
 


### PR DESCRIPTION
The `api_version` output was added in a previous commit and is
no longer used.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>