### PR TITLE
Add a switch to remove the built-in authentication

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,11 +31,12 @@ if settings.get("BOOTSTRAP_NODE", False) is True:
 logging.info(f"Bootstrap on this node enabled: {settings.BOOTSTRAP_NODE}")
 logging.info(f"Bootstrap ID: {settings_repository.get_fresh('BOOTSTRAP')}")
 
-if settings.get("TOKENS_NODE", True) is True:
+is_authentication_enabled: bool = settings.get("AUTH", True)
+if settings.get("TOKENS_NODE", True) is True and is_authentication_enabled:
     api_v1.include_router(token_v1)
-logging.info(
-    f"Tokens on this node enabled: {settings.get('TOKENS_NODE', True)}"
-)
+    logging.info(
+        f"Tokens on this node enabled: {settings.get('TOKENS_NODE', True)}"
+    )
 
 api_v1.include_router(config_v1)
 api_v1.include_router(targets_v1)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,8 @@ services:
       - RSTUF_REDIS_SERVER="redis://redis"
       - SECRETS_RSTUF_TOKEN_KEY="secret"
       - SECRETS_RSTUF_ADMIN_PASSWORD="secret"
+      # If you want to test without authentication uncomment the next line:
+      # - RSTUF_AUTH=false
     volumes:
       - ./:/opt/repository-service-tuf-api:z
     depends_on:

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -87,11 +87,16 @@ These settings are shared with the repository workers
 
 Important: It should use the same db id as used by RSTUF Workers.
 
-#### (Required) `SECRETS_RSTUF_TOKEN_KEY`
+#### (Required) `RSTUF_AUTH`
+Disable/Enable RSTUF built-in token authentication. Default: true
+
+Note: Disable this feature only if you have set up another authentication provider.
+
+##### (Required) `SECRETS_RSTUF_TOKEN_KEY`
 
 Secret Token for hash the Tokens.
 
-#### (Required) `SECRETS_RSTUF_ADMIN_PASSWORD`
+##### (Required) `SECRETS_RSTUF_ADMIN_PASSWORD`
 
 Secret admin password.
 

--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -90,8 +90,6 @@ Important: It should use the same db id as used by RSTUF Workers.
 #### (Required) `RSTUF_AUTH`
 Disable/Enable RSTUF built-in token authentication. Default: true
 
-Note: Disable this feature only if you have set up another authentication provider.
-
 ##### (Required) `SECRETS_RSTUF_TOKEN_KEY`
 
 Secret Token for hash the Tokens.

--- a/repository_service_tuf_api/api/__init__.py
+++ b/repository_service_tuf_api/api/__init__.py
@@ -1,3 +1,24 @@
 # SPDX-FileCopyrightText: 2022-2023 VMware Inc
 #
 # SPDX-License-Identifier: MIT
+
+import logging
+from typing import Callable
+
+from repository_service_tuf_api import settings
+from repository_service_tuf_api.token import validate_token
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%H:%M:%S",
+)
+
+
+def get_auth() -> Callable:
+    if settings.get("AUTH", True) is True:
+        logging.debug("RSTUF builtin auth is enabled")
+        return validate_token
+    else:
+        logging.debug("RSTUF builtin auth is disabled")
+        return lambda: None

--- a/repository_service_tuf_api/api/__init__.py
+++ b/repository_service_tuf_api/api/__init__.py
@@ -8,12 +8,6 @@ from typing import Callable
 from repository_service_tuf_api import settings
 from repository_service_tuf_api.token import validate_token
 
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="%(asctime)s %(levelname)s %(message)s",
-    datefmt="%H:%M:%S",
-)
-
 
 def get_auth() -> Callable:
     if settings.get("AUTH", True) is True:

--- a/repository_service_tuf_api/api/bootstrap.py
+++ b/repository_service_tuf_api/api/bootstrap.py
@@ -5,13 +5,15 @@
 from fastapi import APIRouter, Security, status
 
 from repository_service_tuf_api import SCOPES_NAMES, bootstrap
-from repository_service_tuf_api.token import validate_token
+from repository_service_tuf_api.api import get_auth
 
 router = APIRouter(
     prefix="/bootstrap",
     tags=["v1"],
     responses={404: {"description": "Not found"}},
 )
+
+auth = get_auth()
 
 
 @router.get(
@@ -24,9 +26,7 @@ router = APIRouter(
     response_model=bootstrap.BootstrapGetResponse,
     response_model_exclude_none=True,
 )
-def get(
-    _user=Security(validate_token, scopes=[SCOPES_NAMES.read_bootstrap.value])
-):
+def get(_user=Security(auth, scopes=[SCOPES_NAMES.read_bootstrap.value])):
     return bootstrap.get_bootstrap()
 
 
@@ -46,8 +46,6 @@ def get(
 )
 def post(
     payload: bootstrap.BootstrapPayload,
-    _user=Security(
-        validate_token, scopes=[SCOPES_NAMES.write_bootstrap.value]
-    ),
+    _user=Security(auth, scopes=[SCOPES_NAMES.write_bootstrap.value]),
 ):
     return bootstrap.post_bootstrap(payload)

--- a/repository_service_tuf_api/api/config.py
+++ b/repository_service_tuf_api/api/config.py
@@ -5,7 +5,9 @@
 from fastapi import APIRouter, Security
 
 from repository_service_tuf_api import SCOPES_NAMES, config
-from repository_service_tuf_api.token import validate_token
+from repository_service_tuf_api.api import get_auth
+
+auth = get_auth()
 
 router = APIRouter(
     prefix="/config",
@@ -21,7 +23,5 @@ router = APIRouter(
     response_model=config.Response,
     response_model_exclude_none=True,
 )
-def get(
-    _user=Security(validate_token, scopes=[SCOPES_NAMES.read_settings.value])
-):
+def get(_user=Security(auth, scopes=[SCOPES_NAMES.read_settings.value])):
     return config.get()

--- a/repository_service_tuf_api/api/targets.py
+++ b/repository_service_tuf_api/api/targets.py
@@ -5,7 +5,9 @@
 from fastapi import APIRouter, Security, status
 
 from repository_service_tuf_api import SCOPES_NAMES, targets
-from repository_service_tuf_api.token import validate_token
+from repository_service_tuf_api.api import get_auth
+
+auth = get_auth()
 
 router = APIRouter(
     prefix="/targets",
@@ -27,7 +29,7 @@ router = APIRouter(
 )
 def post(
     payload: targets.AddPayload,
-    _user=Security(validate_token, scopes=[SCOPES_NAMES.write_targets.value]),
+    _user=Security(auth, scopes=[SCOPES_NAMES.write_targets.value]),
 ):
     return targets.post(payload)
 
@@ -45,7 +47,7 @@ def post(
 )
 def delete(
     payload: targets.DeletePayload,
-    _user=Security(validate_token, scopes=[SCOPES_NAMES.delete_targets.value]),
+    _user=Security(auth, scopes=[SCOPES_NAMES.delete_targets.value]),
 ):
     return targets.delete(payload)
 
@@ -65,6 +67,6 @@ def delete(
     status_code=status.HTTP_202_ACCEPTED,
 )
 def post_publish_targets(
-    _user=Security(validate_token, scopes=[SCOPES_NAMES.write_targets.value]),
+    _user=Security(auth, scopes=[SCOPES_NAMES.write_targets.value]),
 ):
     return targets.post_publish_targets()

--- a/repository_service_tuf_api/api/tasks.py
+++ b/repository_service_tuf_api/api/tasks.py
@@ -5,7 +5,9 @@
 from fastapi import APIRouter, Depends, Security
 
 from repository_service_tuf_api import SCOPES_NAMES, tasks
-from repository_service_tuf_api.token import validate_token
+from repository_service_tuf_api.api import get_auth
+
+auth = get_auth()
 
 router = APIRouter(
     prefix="/task",
@@ -32,6 +34,6 @@ router = APIRouter(
 )
 def get(
     params: tasks.GetParameters = Depends(),
-    _user=Security(validate_token, scopes=[SCOPES_NAMES.read_tasks.value]),
+    _user=Security(auth, scopes=[SCOPES_NAMES.read_tasks.value]),
 ):
     return tasks.get(params.task_id)


### PR DESCRIPTION
Introduce `RSTUF_AUTH` env variable which will allow for external
authentication providers to be plugged in.

Also, exclude all token-related API
calls when authentication is not used.

For the rest of the API calls introduce a switch that allows
to disable their authentication.

Close #282 