### PR TITLE
fix/enhancement RSTUF API about AUTH feature

### DIFF
--- a/docs/source/guide/Docker_README.md
+++ b/docs/source/guide/Docker_README.md
@@ -87,7 +87,8 @@ These settings are shared with the repository workers
 
 Important: It should use the same db id as used by RSTUF Workers.
 
-#### (Required) `RSTUF_AUTH`
+#### (Optional) `RSTUF_AUTH`
+
 Disable/Enable RSTUF built-in token authentication. Default: true
 
 ##### (Required) `SECRETS_RSTUF_TOKEN_KEY`

--- a/docs/source/guide/api.rst
+++ b/docs/source/guide/api.rst
@@ -5,6 +5,12 @@ Repository Service for TUF REST API Documentation
 API Authentication and Authorization
 ====================================
 
+.. note::
+    The build-in feature authentication and authorization can be disabled.
+
+    For disabling see the `Docker Image RSTUF_AUTH environment variable
+    <Docker_README.html#optional-rstuf-auth>`_
+
 The ``admin`` user can request a token using the Authentication endpoint
 ``api/v1/token/``. The API will give the token with expiration (in hours).
 The Default is 1 (hour).


### PR DESCRIPTION
- fix the option `RSTUF_AUTH` as optional
- Add a note in the API documentation and add reference how to disable it.